### PR TITLE
feat: add schema_filter_pattern for wildcard schema filtering

### DIFF
--- a/apps/dbxmetagen-app/app/api_server.py
+++ b/apps/dbxmetagen-app/app/api_server.py
@@ -426,6 +426,7 @@ class JobRunRequest(BaseModel):
     schema_name: Optional[str] = None
     ontology_bundle: Optional[str] = None
     domain_config: Optional[str] = None
+    schema_filter_pattern: Optional[str] = None
     extra_params: dict = {}
 
 
@@ -702,6 +703,8 @@ def run_job(req: JobRunRequest):
         params["ontology_bundle"] = req.ontology_bundle
     if req.domain_config:
         params["domain_config_path"] = _resolve_domain_config_path(req.domain_config)
+    if req.schema_filter_pattern:
+        params["schema_filter_pattern"] = req.schema_filter_pattern
     params.update(req.extra_params)
     try:
         run = ws.jobs.run_now(job_id=target_job_id, job_parameters=params)

--- a/apps/dbxmetagen-app/app/src/components/BatchJobs.jsx
+++ b/apps/dbxmetagen-app/app/src/components/BatchJobs.jsx
@@ -146,6 +146,7 @@ export default function BatchJobs({ onNavigate }) {
   const [bundles, setBundles] = useState([])
   const [domainConfig, setDomainConfig] = useState('')
   const [domainConfigs, setDomainConfigs] = useState([])
+  const [schemaFilterPattern, setSchemaFilterPattern] = useState('')
   const [runHistory, setRunHistory] = useState([])
   const [historyPage, setHistoryPage] = useState(0)
   const [health, setHealth] = useState(null)
@@ -526,16 +527,22 @@ export default function BatchJobs({ onNavigate }) {
                   <input type="checkbox" checked={applyDdl} onChange={e => setApplyDdl(e.target.checked)} />
                   Apply DDL directly
                 </label>
+                <div>
+                  <label className="text-sm font-medium text-slate-700 dark:text-slate-200 mb-1.5 block">Schema Filter (regex)</label>
+                  <input type="text" value={schemaFilterPattern} onChange={e => setSchemaFilterPattern(e.target.value)}
+                    placeholder='e.g. ^(gold|curated|published)' className="input-base" />
+                  <p className="text-xs text-slate-400 mt-1">Only expand wildcard schemas matching this pattern. Leave empty for all.</p>
+                </div>
               </div>
             </div>
             <div className="flex flex-wrap gap-3 mt-2">
-              <button onClick={() => runJob(getJobSuffix(false), { table_names: tableNames, mode, apply_ddl: applyDdl, ontology_bundle: ontologyBundle, ...(domainConfig ? { domain_config: domainConfig } : {}), extra_params: buildExtraParams() }, 'single')}
+              <button onClick={() => runJob(getJobSuffix(false), { table_names: tableNames, mode, apply_ddl: applyDdl, ontology_bundle: ontologyBundle, ...(domainConfig ? { domain_config: domainConfig } : {}), ...(schemaFilterPattern ? { schema_filter_pattern: schemaFilterPattern } : {}), extra_params: buildExtraParams() }, 'single')}
                 disabled={!!runningAction || !tableNames.trim()} title="Run a single metadata generation pass"
                 className="btn-secondary btn-md">{runningAction === 'single' ? 'Starting...' : `Run Single Mode${settings.build_kb_after ? ' + KB' : ''}${settings.use_serverless ? ' (Serverless)' : ''}`}</button>
-              <button onClick={() => runJob(getJobSuffix(true), { table_names: tableNames, apply_ddl: applyDdl, ontology_bundle: ontologyBundle, ...(domainConfig ? { domain_config: domainConfig } : {}), extra_params: buildExtraParams() }, 'all3')}
+              <button onClick={() => runJob(getJobSuffix(true), { table_names: tableNames, apply_ddl: applyDdl, ontology_bundle: ontologyBundle, ...(domainConfig ? { domain_config: domainConfig } : {}), ...(schemaFilterPattern ? { schema_filter_pattern: schemaFilterPattern } : {}), extra_params: buildExtraParams() }, 'all3')}
                 disabled={!!runningAction || !tableNames.trim()} title="Run all three modes in parallel"
                 className="btn-primary btn-md">{runningAction === 'all3' ? 'Starting...' : `All 3 Modes${settings.build_kb_after ? ' + KB' : ''}${settings.use_serverless ? ' (Serverless)' : ''}`}</button>
-              <button onClick={() => runJob('_kb_enriched_modes_job', { table_names: tableNames, apply_ddl: applyDdl, ontology_bundle: ontologyBundle, ...(domainConfig ? { domain_config: domainConfig } : {}), extra_params: buildExtraParams() }, 'kb_enriched')}
+              <button onClick={() => runJob('_kb_enriched_modes_job', { table_names: tableNames, apply_ddl: applyDdl, ontology_bundle: ontologyBundle, ...(domainConfig ? { domain_config: domainConfig } : {}), ...(schemaFilterPattern ? { schema_filter_pattern: schemaFilterPattern } : {}), extra_params: buildExtraParams() }, 'kb_enriched')}
                 disabled={!!runningAction || !tableNames.trim()} title="Comments -> KB build -> PI + Domain with KB enrichment"
                 className="btn-md bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 disabled:opacity-50 transition-all">{runningAction === 'kb_enriched' ? 'Starting...' : 'KB-Enriched Modes'}</button>
             </div>

--- a/resources/jobs/enriched_first_pipeline.job.yml
+++ b/resources/jobs/enriched_first_pipeline.job.yml
@@ -48,6 +48,8 @@ resources:
           default: "true"
         - name: include_constraint_context
           default: "true"
+        - name: schema_filter_pattern
+          default: ""
 
       tasks:
         # ------------------------------------------------------------------
@@ -131,6 +133,7 @@ resources:
               include_constraint_context: "{{job.parameters.include_constraint_context}}"
               ontology_bundle: "{{job.parameters.ontology_bundle}}"
               domain_config_path: "{{job.parameters.domain_config_path}}"
+              schema_filter_pattern: "{{job.parameters.schema_filter_pattern}}"
           libraries:
             - whl: ../../dist/*.whl
 
@@ -150,6 +153,7 @@ resources:
               run_id: "{{job.parameters.run_id}}"
               ontology_bundle: "{{job.parameters.ontology_bundle}}"
               domain_config_path: "{{job.parameters.domain_config_path}}"
+              schema_filter_pattern: "{{job.parameters.schema_filter_pattern}}"
           libraries:
             - whl: ../../dist/*.whl
 
@@ -169,6 +173,7 @@ resources:
               run_id: "{{job.parameters.run_id}}"
               ontology_bundle: "{{job.parameters.ontology_bundle}}"
               domain_config_path: "{{job.parameters.domain_config_path}}"
+              schema_filter_pattern: "{{job.parameters.schema_filter_pattern}}"
           libraries:
             - whl: ../../dist/*.whl
 

--- a/resources/jobs/metagen.job.yml
+++ b/resources/jobs/metagen.job.yml
@@ -45,6 +45,8 @@ resources:
           default: "false"
         - name: model
           default: "databricks-claude-sonnet-4-6"
+        - name: schema_filter_pattern
+          default: ""
 
       tasks:
         - task_key: generate_metadata
@@ -68,6 +70,7 @@ resources:
               sample_size: "{{job.parameters.sample_size}}"
               include_lineage: "{{job.parameters.include_lineage}}"
               model: "{{job.parameters.model}}"
+              schema_filter_pattern: "{{job.parameters.schema_filter_pattern}}"
 
           libraries:
             - whl: ../../dist/*.whl

--- a/resources/jobs/metagen_kb_build.job.yml
+++ b/resources/jobs/metagen_kb_build.job.yml
@@ -51,6 +51,8 @@ resources:
           default: "false"
         - name: model
           default: "databricks-claude-sonnet-4-6"
+        - name: schema_filter_pattern
+          default: ""
 
       tasks:
         - task_key: generate_metadata
@@ -73,6 +75,7 @@ resources:
               sample_size: "{{job.parameters.sample_size}}"
               include_lineage: "{{job.parameters.include_lineage}}"
               model: "{{job.parameters.model}}"
+              schema_filter_pattern: "{{job.parameters.schema_filter_pattern}}"
           libraries:
             - whl: ../../dist/*.whl
 

--- a/resources/jobs/metagen_kb_enriched.job.yml
+++ b/resources/jobs/metagen_kb_enriched.job.yml
@@ -47,6 +47,8 @@ resources:
           default: "false"
         - name: model
           default: "databricks-claude-sonnet-4-6"
+        - name: schema_filter_pattern
+          default: ""
 
       tasks:
         - task_key: generate_comments
@@ -70,6 +72,7 @@ resources:
               sample_size: "{{job.parameters.sample_size}}"
               include_lineage: "{{job.parameters.include_lineage}}"
               model: "{{job.parameters.model}}"
+              schema_filter_pattern: "{{job.parameters.schema_filter_pattern}}"
           libraries:
             - whl: ../../dist/*.whl
 
@@ -110,6 +113,7 @@ resources:
               sample_size: "{{job.parameters.sample_size}}"
               include_lineage: "{{job.parameters.include_lineage}}"
               model: "{{job.parameters.model}}"
+              schema_filter_pattern: "{{job.parameters.schema_filter_pattern}}"
           libraries:
             - whl: ../../dist/*.whl
 
@@ -138,6 +142,7 @@ resources:
               sample_size: "{{job.parameters.sample_size}}"
               include_lineage: "{{job.parameters.include_lineage}}"
               model: "{{job.parameters.model}}"
+              schema_filter_pattern: "{{job.parameters.schema_filter_pattern}}"
           libraries:
             - whl: ../../dist/*.whl
 

--- a/resources/jobs/metagen_parallel_kb_build.job.yml
+++ b/resources/jobs/metagen_parallel_kb_build.job.yml
@@ -49,6 +49,8 @@ resources:
           default: "false"
         - name: model
           default: "databricks-claude-sonnet-4-6"
+        - name: schema_filter_pattern
+          default: ""
 
       tasks:
         - task_key: generate_comments
@@ -72,6 +74,7 @@ resources:
               sample_size: "{{job.parameters.sample_size}}"
               include_lineage: "{{job.parameters.include_lineage}}"
               model: "{{job.parameters.model}}"
+              schema_filter_pattern: "{{job.parameters.schema_filter_pattern}}"
           libraries:
             - whl: ../../dist/*.whl
 
@@ -100,6 +103,7 @@ resources:
               sample_size: "{{job.parameters.sample_size}}"
               include_lineage: "{{job.parameters.include_lineage}}"
               model: "{{job.parameters.model}}"
+              schema_filter_pattern: "{{job.parameters.schema_filter_pattern}}"
           libraries:
             - whl: ../../dist/*.whl
 
@@ -128,6 +132,7 @@ resources:
               sample_size: "{{job.parameters.sample_size}}"
               include_lineage: "{{job.parameters.include_lineage}}"
               model: "{{job.parameters.model}}"
+              schema_filter_pattern: "{{job.parameters.schema_filter_pattern}}"
           libraries:
             - whl: ../../dist/*.whl
 

--- a/resources/jobs/metagen_parallel_modes.job.yml
+++ b/resources/jobs/metagen_parallel_modes.job.yml
@@ -49,6 +49,8 @@ resources:
           default: "false"
         - name: model
           default: "databricks-claude-sonnet-4-6"
+        - name: schema_filter_pattern
+          default: ""
 
       tasks:
         # Comments run first; PI and domain depend on it so they can use comments
@@ -73,6 +75,7 @@ resources:
               sample_size: "{{job.parameters.sample_size}}"
               include_lineage: "{{job.parameters.include_lineage}}"
               model: "{{job.parameters.model}}"
+              schema_filter_pattern: "{{job.parameters.schema_filter_pattern}}"
           libraries:
             - whl: ../../dist/*.whl
 
@@ -101,6 +104,7 @@ resources:
               sample_size: "{{job.parameters.sample_size}}"
               include_lineage: "{{job.parameters.include_lineage}}"
               model: "{{job.parameters.model}}"
+              schema_filter_pattern: "{{job.parameters.schema_filter_pattern}}"
           libraries:
             - whl: ../../dist/*.whl
 
@@ -129,6 +133,7 @@ resources:
               sample_size: "{{job.parameters.sample_size}}"
               include_lineage: "{{job.parameters.include_lineage}}"
               model: "{{job.parameters.model}}"
+              schema_filter_pattern: "{{job.parameters.schema_filter_pattern}}"
           libraries:
             - whl: ../../dist/*.whl
 

--- a/resources/jobs/metagen_parallel_serverless.job.yml
+++ b/resources/jobs/metagen_parallel_serverless.job.yml
@@ -49,6 +49,8 @@ resources:
           default: "false"
         - name: model
           default: "databricks-claude-sonnet-4-6"
+        - name: schema_filter_pattern
+          default: ""
 
       tasks:
         - task_key: generate_comments
@@ -72,6 +74,7 @@ resources:
               sample_size: "{{job.parameters.sample_size}}"
               include_lineage: "{{job.parameters.include_lineage}}"
               model: "{{job.parameters.model}}"
+              schema_filter_pattern: "{{job.parameters.schema_filter_pattern}}"
 
         - task_key: generate_pi
           depends_on:
@@ -98,6 +101,7 @@ resources:
               sample_size: "{{job.parameters.sample_size}}"
               include_lineage: "{{job.parameters.include_lineage}}"
               model: "{{job.parameters.model}}"
+              schema_filter_pattern: "{{job.parameters.schema_filter_pattern}}"
 
         - task_key: generate_domain
           depends_on:
@@ -124,6 +128,7 @@ resources:
               sample_size: "{{job.parameters.sample_size}}"
               include_lineage: "{{job.parameters.include_lineage}}"
               model: "{{job.parameters.model}}"
+              schema_filter_pattern: "{{job.parameters.schema_filter_pattern}}"
 
         - task_key: build_knowledge_base
           depends_on:

--- a/resources/jobs/metagen_serverless.job.yml
+++ b/resources/jobs/metagen_serverless.job.yml
@@ -51,6 +51,8 @@ resources:
           default: "false"
         - name: model
           default: "databricks-claude-sonnet-4-6"
+        - name: schema_filter_pattern
+          default: ""
 
       tasks:
         - task_key: generate_metadata
@@ -73,6 +75,7 @@ resources:
               sample_size: "{{job.parameters.sample_size}}"
               include_lineage: "{{job.parameters.include_lineage}}"
               model: "{{job.parameters.model}}"
+              schema_filter_pattern: "{{job.parameters.schema_filter_pattern}}"
 
         - task_key: build_knowledge_base
           depends_on:

--- a/resources/jobs/metagen_with_kb.job.yml
+++ b/resources/jobs/metagen_with_kb.job.yml
@@ -31,6 +31,8 @@ resources:
           default: "{{job.run_id}}"
         - name: include_previously_failed_tables
           default: "false"
+        - name: schema_filter_pattern
+          default: ""
 
       tasks:
         - task_key: generate_metadata
@@ -47,6 +49,7 @@ resources:
               permission_users: "{{job.parameters.permission_users}}"
               run_id: "{{job.parameters.run_id}}"
               include_previously_failed_tables: "{{job.parameters.include_previously_failed_tables}}"
+              schema_filter_pattern: "{{job.parameters.schema_filter_pattern}}"
 
           libraries:
             - whl: ../../dist/*.whl

--- a/src/dbxmetagen/config.py
+++ b/src/dbxmetagen/config.py
@@ -115,6 +115,7 @@ class MetadataConfig:
             "use_kb_comments",
             "include_profiling_context",
             "include_constraint_context",
+            "schema_filter_pattern",
         ],
         "yaml_advanced_file_path": "../variables.advanced.yml",
         "yaml_advanced_variable_names": [

--- a/src/dbxmetagen/databricks_utils.py
+++ b/src/dbxmetagen/databricks_utils.py
@@ -135,6 +135,7 @@ def setup_widgets(dbutils):
     dbutils.widgets.text("domain_config_path", "")
     dbutils.widgets.text("include_lineage", "")
     dbutils.widgets.text("model", "")
+    dbutils.widgets.text("schema_filter_pattern", "", "Schema Filter Pattern (regex)")
     dbutils.widgets.dropdown(
         "allow_manual_override", "true", ["true", "false"], "Allow Manual Override"
     )
@@ -160,6 +161,7 @@ def get_widgets(dbutils):
     domain_config_path = dbutils.widgets.get("domain_config_path")
     include_lineage = dbutils.widgets.get("include_lineage")
     model = dbutils.widgets.get("model")
+    schema_filter_pattern = dbutils.widgets.get("schema_filter_pattern")
     allow_manual_override = dbutils.widgets.get("allow_manual_override")
     override_csv_path = dbutils.widgets.get("override_csv_path")
     notebook_variables = {
@@ -180,6 +182,7 @@ def get_widgets(dbutils):
         "domain_config_path": domain_config_path,
         "include_lineage": include_lineage,
         "model": model,
+        "schema_filter_pattern": schema_filter_pattern,
         "allow_manual_override": allow_manual_override,
         "override_csv_path": override_csv_path,
     }

--- a/src/dbxmetagen/processing.py
+++ b/src/dbxmetagen/processing.py
@@ -3223,8 +3223,9 @@ def setup_queue(config: MetadataConfig) -> List[str]:
         name.strip() for name in config_table_string.split(",") if len(name.strip()) > 0
     ]
     # Expand schema wildcards in config table names as well
-    config_table_names = expand_schema_wildcards(config_table_names)
-    file_table_names = load_table_names_from_csv(config.source_file_path)
+    schema_filter = getattr(config, "schema_filter_pattern", None) or None
+    config_table_names = expand_schema_wildcards(config_table_names, schema_filter)
+    file_table_names = load_table_names_from_csv(config.source_file_path, schema_filter)
     
     # If include_previously_failed_tables is enabled, also include failed/abandoned tables
     mode = config.mode or "comment"
@@ -3372,7 +3373,7 @@ def upsert_table_names_to_control_table(
                 raise
 
 
-def load_table_names_from_csv(csv_file_path):
+def load_table_names_from_csv(csv_file_path, schema_filter_pattern: str = None):
     """Check if the CSV file exists and load table names."""
     if not csv_file_path or not os.path.exists(csv_file_path):
         print(
@@ -3393,7 +3394,7 @@ def load_table_names_from_csv(csv_file_path):
         print(f"Successfully loaded {len(table_names)} table names from CSV")
 
         sanitized_names = sanitize_string_list(table_names)
-        expanded_names = expand_schema_wildcards(sanitized_names)
+        expanded_names = expand_schema_wildcards(sanitized_names, schema_filter_pattern)
         return expanded_names
 
     except Exception as e:
@@ -3418,7 +3419,7 @@ _UNREADABLE_FORMATS = frozenset({"VECTOR_INDEX_FORMAT"})
 _UNREADABLE_TABLE_TYPES = frozenset({"METRIC_VIEW", "METRIC VIEW"})
 
 
-def get_tables_in_schema(catalog_name: str, schema_name: str) -> List[str]:
+def get_tables_in_schema(catalog_name: str, schema_name: str, schema_filter_pattern: str = None) -> List[str]:
     """
     Get all table names in a given catalog and schema.
     Excludes metric views and non-readable data source formats (e.g. vector
@@ -3427,10 +3428,20 @@ def get_tables_in_schema(catalog_name: str, schema_name: str) -> List[str]:
     Args:
         catalog_name (str): The catalog name.
         schema_name (str): The schema name.
+        schema_filter_pattern (str, optional): Regex to filter schema names.
+            If provided and the schema_name does not match, returns [].
 
     Returns:
         List[str]: A list of fully qualified table names.
     """
+    if schema_filter_pattern:
+        try:
+            if not re.search(schema_filter_pattern, schema_name, re.IGNORECASE):
+                print(f"Schema '{schema_name}' excluded by filter '{schema_filter_pattern}'")
+                return []
+        except re.error as e:
+            print(f"Warning: Invalid schema_filter_pattern '{schema_filter_pattern}': {e}, including all schemas")
+
     spark = SparkSession.builder.getOrCreate()
 
     try:
@@ -3464,12 +3475,13 @@ def get_tables_in_schema(catalog_name: str, schema_name: str) -> List[str]:
         return []
 
 
-def expand_schema_wildcards(table_names: List[str]) -> List[str]:
+def expand_schema_wildcards(table_names: List[str], schema_filter_pattern: str = None) -> List[str]:
     """
     Expand schema wildcard patterns in a list of table names.
 
     Args:
         table_names (List[str]): List of table names, possibly containing wildcards.
+        schema_filter_pattern (str, optional): Regex to filter which schemas are expanded.
 
     Returns:
         List[str]: Expanded list of table names with wildcards resolved.
@@ -3483,7 +3495,7 @@ def expand_schema_wildcards(table_names: List[str]) -> List[str]:
             if len(parts) == 2:
                 catalog_name, schema_name = parts
                 # Get all tables in the schema
-                schema_tables = get_tables_in_schema(catalog_name, schema_name)
+                schema_tables = get_tables_in_schema(catalog_name, schema_name, schema_filter_pattern)
                 expanded_names.extend(schema_tables)
                 print(f"Expanded {table_name} to {len(schema_tables)} tables")
             else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -175,6 +175,7 @@ def base_config_kwargs():
         "include_deterministic_pi": False,
         "tag_none_fields": True,
         "federation_mode": False,
+        "schema_filter_pattern": "",
     }
 
 

--- a/tests/test_schema_filter.py
+++ b/tests/test_schema_filter.py
@@ -1,0 +1,188 @@
+"""Tests for schema_filter_pattern feature in wildcard expansion."""
+
+import sys
+import os
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+# Re-use conftest stubs (conftest.py is auto-loaded by pytest)
+from conftest import install_processing_stubs, uninstall_processing_stubs
+
+
+@pytest.fixture(autouse=True)
+def _processing_stubs():
+    """Install/uninstall processing stubs around each test."""
+    saved = install_processing_stubs()
+    yield
+    uninstall_processing_stubs(saved)
+
+
+def _import_processing():
+    """Import processing module after stubs are in place."""
+    from dbxmetagen import processing
+    return processing
+
+
+def _setup_spark_mock(table_rows=None):
+    """Configure the globally-mocked SparkSession to return given rows.
+
+    Returns the mock spark instance so callers can assert on sql() calls.
+    """
+    mock_spark = MagicMock()
+    if table_rows is None:
+        table_rows = []
+    mock_spark.sql.return_value.collect.return_value = table_rows
+    # Patch the global mock so SparkSession.builder.getOrCreate() returns our mock
+    spark_mod = sys.modules["pyspark.sql"]
+    spark_mod.SparkSession.builder.getOrCreate.return_value = mock_spark
+    return mock_spark
+
+
+def _make_table_row(table_name="t1", table_type="MANAGED", data_source_format="DELTA"):
+    row = MagicMock()
+    row.table_name = table_name
+    row.table_type = table_type
+    row.data_source_format = data_source_format
+    return row
+
+
+# --- get_tables_in_schema filter tests ---
+
+class TestGetTablesInSchemaFilter:
+    """Test that schema_filter_pattern is applied BEFORE the SQL query."""
+
+    def test_matching_schema_queries_tables(self):
+        proc = _import_processing()
+        mock_spark = _setup_spark_mock([_make_table_row("patients")])
+
+        result = proc.get_tables_in_schema("cat", "gold_layer", schema_filter_pattern="^gold")
+        assert result == ["cat.gold_layer.patients"]
+        mock_spark.sql.assert_called_once()
+
+    def test_non_matching_schema_returns_empty(self):
+        proc = _import_processing()
+        mock_spark = _setup_spark_mock([_make_table_row()])
+
+        result = proc.get_tables_in_schema("cat", "bronze_raw", schema_filter_pattern="^gold")
+        assert result == []
+        # SQL was NOT called — filtered before query
+        mock_spark.sql.assert_not_called()
+
+    def test_case_insensitive_match(self):
+        proc = _import_processing()
+        _setup_spark_mock([_make_table_row()])
+
+        result = proc.get_tables_in_schema("cat", "GOLD_layer", schema_filter_pattern="^gold")
+        assert len(result) == 1
+
+    def test_invalid_regex_includes_all(self):
+        proc = _import_processing()
+        mock_spark = _setup_spark_mock([_make_table_row()])
+
+        # Invalid regex — should NOT exclude, just warn
+        result = proc.get_tables_in_schema("cat", "any_schema", schema_filter_pattern="[invalid")
+        assert len(result) == 1
+        mock_spark.sql.assert_called_once()
+
+    def test_no_filter_includes_all(self):
+        proc = _import_processing()
+        _setup_spark_mock([_make_table_row()])
+
+        result = proc.get_tables_in_schema("cat", "anything", schema_filter_pattern=None)
+        assert len(result) == 1
+
+    def test_empty_string_filter_includes_all(self):
+        proc = _import_processing()
+        _setup_spark_mock([_make_table_row()])
+
+        # Empty string should behave like no filter
+        result = proc.get_tables_in_schema("cat", "anything", schema_filter_pattern="")
+        assert len(result) == 1
+
+
+# --- expand_schema_wildcards filter tests ---
+
+class TestExpandSchemaWildcardsFilter:
+    """Test that schema_filter_pattern is passed through expand_schema_wildcards."""
+
+    def test_wildcard_with_matching_filter(self):
+        proc = _import_processing()
+        with patch.object(proc, "get_tables_in_schema", return_value=["cat.gold.t1", "cat.gold.t2"]) as mock_get:
+            result = proc.expand_schema_wildcards(["cat.gold.*"], schema_filter_pattern="^gold")
+            assert result == ["cat.gold.t1", "cat.gold.t2"]
+            mock_get.assert_called_once_with("cat", "gold", "^gold")
+
+    def test_wildcard_with_non_matching_filter(self):
+        proc = _import_processing()
+        with patch.object(proc, "get_tables_in_schema", return_value=[]) as mock_get:
+            result = proc.expand_schema_wildcards(["cat.bronze.*"], schema_filter_pattern="^gold")
+            assert result == []
+            mock_get.assert_called_once_with("cat", "bronze", "^gold")
+
+    def test_explicit_table_bypasses_filter(self):
+        """Explicit table names (no wildcard) should never be filtered."""
+        proc = _import_processing()
+        with patch.object(proc, "get_tables_in_schema") as mock_get:
+            result = proc.expand_schema_wildcards(
+                ["cat.bronze.specific_table"],
+                schema_filter_pattern="^gold"
+            )
+            assert result == ["cat.bronze.specific_table"]
+            mock_get.assert_not_called()
+
+    def test_mixed_wildcards_and_explicit(self):
+        proc = _import_processing()
+        with patch.object(proc, "get_tables_in_schema", return_value=["cat.gold.t1"]) as mock_get:
+            result = proc.expand_schema_wildcards(
+                ["cat.gold.*", "cat.bronze.explicit_table"],
+                schema_filter_pattern="^gold"
+            )
+            assert "cat.gold.t1" in result
+            assert "cat.bronze.explicit_table" in result
+            assert len(result) == 2
+
+    def test_no_filter_backward_compat(self):
+        proc = _import_processing()
+        with patch.object(proc, "get_tables_in_schema", return_value=["cat.s.t1"]) as mock_get:
+            result = proc.expand_schema_wildcards(["cat.s.*"])
+            assert result == ["cat.s.t1"]
+            mock_get.assert_called_once_with("cat", "s", None)
+
+    def test_negative_lookahead_pattern(self):
+        """Verify negative lookahead works for excluding staging/temp schemas."""
+        proc = _import_processing()
+        calls = []
+
+        def fake_get(cat, schema, filt=None):
+            calls.append(schema)
+            import re
+            if filt and not re.search(filt, schema, re.IGNORECASE):
+                return []
+            return [f"{cat}.{schema}.t1"]
+
+        with patch.object(proc, "get_tables_in_schema", side_effect=fake_get):
+            result = proc.expand_schema_wildcards(
+                ["cat.gold.*", "cat.staging.*", "cat.curated.*"],
+                schema_filter_pattern="^(?!staging|temp)"
+            )
+            assert "cat.gold.t1" in result
+            assert "cat.curated.t1" in result
+
+
+# --- load_table_names_from_csv filter passthrough test ---
+
+class TestLoadTableNamesFromCsvFilter:
+    """Test that schema_filter_pattern is passed through to expand_schema_wildcards."""
+
+    def test_csv_filter_passed_to_expand(self, tmp_path):
+        proc = _import_processing()
+        csv_file = tmp_path / "tables.csv"
+        csv_file.write_text("table_name\ncat.gold.*\ncat.bronze.*\n")
+
+        with patch.object(proc, "expand_schema_wildcards", return_value=["cat.gold.t1"]) as mock_expand:
+            result = proc.load_table_names_from_csv(str(csv_file), schema_filter_pattern="^gold")
+            assert result == ["cat.gold.t1"]
+            # Verify the filter was passed positionally to expand_schema_wildcards
+            mock_expand.assert_called_once()
+            assert mock_expand.call_args[0][1] == "^gold"

--- a/variables.yml
+++ b/variables.yml
@@ -221,3 +221,6 @@ variables:
   include_constraint_context:
     description: "When true, inject PK/FK constraint roles into comment generation prompts. Requires extended metadata extraction to have run first."
     default: false
+  schema_filter_pattern:
+    description: "Regex pattern to filter which schemas are expanded during wildcard resolution (e.g. catalog.schema.*). Only schemas whose name matches the pattern will be included. Empty string means no filtering (all schemas included). Case-insensitive. Note: previously failed tables retried via include_previously_failed_tables bypass this filter since they are already fully-qualified table names."
+    default: ""


### PR DESCRIPTION
## Summary

Adds a `schema_filter_pattern` regex parameter that filters which schemas are expanded during wildcard resolution (`catalog.schema.*`). This allows targeting specific schema layers (e.g., gold/curated) without processing every schema in a catalog.

- **Filter at schema level, not table level** — regex matches against the schema name, skipping the `information_schema.tables` query entirely for non-matching schemas
- **Case insensitive** (`re.IGNORECASE`)
- **Invalid regex = include all** (log warning, don't break the run)
- **Explicit table names bypass filter** — `catalog.schema.table` (no wildcard) is never filtered
- **Empty string = no filter** — backward compatible, current behavior preserved exactly

## Motivation

For catalogs with hundreds of schemas (e.g., 318 schemas / 55K+ objects), `catalog.schema.*` expands to ALL tables — no way to target only gold/curated layers. This wastes LLM cost on bronze/raw/staging tables and produces noisy domain classifications on ETL staging tables.

## Example Usage

```yaml
# Only process gold layer schemas
schema_filter_pattern: "^(gold|curated|published|analytics)"

# Exclude staging/temp (negative lookahead)
schema_filter_pattern: "^(?!staging|temp|raw)"
```

## Changes (17 files, +265/-10)

| Layer | Files | Change |
|-------|-------|--------|
| Config | `variables.yml`, `config.py` | Parameter definition + registration |
| Widgets | `databricks_utils.py` | Notebook widget + getter + dict mapping |
| Core logic | `processing.py` | Filter in `get_tables_in_schema()` before SQL query; passthrough in `expand_schema_wildcards()`, `load_table_names_from_csv()`, `setup_queue()` |
| Jobs | 9 metagen job YMLs | Parameter declaration + `base_parameters` mapping |
| API | `api_server.py` | `JobRunRequest` model field + conditional param pass |
| Frontend | `BatchJobs.jsx` | State variable + text input + wired to all 3 run buttons |
| Tests | `test_schema_filter.py` (new), `conftest.py` | 13 tests: match/non-match, case insensitivity, invalid regex fallback, explicit table bypass, mixed lists, negative lookahead, CSV passthrough |

## Design Decisions

1. Previously failed tables retried via `include_previously_failed_tables` bypass this filter — they are already fully-qualified table names, not wildcards. Documented in `variables.yml` description.
2. `getattr(config, "schema_filter_pattern", None)` used defensively for backward compatibility with configs constructed without the field.

## Test plan

- [x] All 1,125 existing tests pass (`pytest tests/ -x --ignore=tests/test_app_logic.py`)
- [x] 13 new schema filter tests pass (`pytest tests/test_schema_filter.py -v`)
- [x] YAML variable coverage test passes (`pytest tests/test_yaml_variable_coverage.py -v`)
- [x] Deployment wiring test passes (`pytest tests/test_deployment_wiring.py -v`)
- [ ] Manual: run metadata job with `schema_filter_pattern: "^metadata"` against a multi-schema catalog

🤖 Generated with [Claude Code](https://claude.com/claude-code)