### PR TITLE
fix: remove all entity purge methods and fix dedup/MERGE keys

### DIFF
--- a/src/dbxmetagen/ontology.py
+++ b/src/dbxmetagen/ontology.py
@@ -2648,14 +2648,13 @@ class EntityDiscoverer:
     def deduplicate_entities(entities: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """Merge duplicate entities from different discovery methods.
 
-        Groups by (source_table, entity_type, granularity) and merges
-        source_columns, takes max confidence, and combines attributes.
+        Groups by (source_table, entity_type) and merges source_columns,
+        takes max confidence, and combines attributes.
         """
         groups: Dict[tuple, Dict[str, Any]] = {}
         for ent in entities:
-            granularity = ent.get("attributes", {}).get("granularity", "table")
             for tbl in ent.get("source_tables", ["unknown"]):
-                key = (tbl, ent["entity_type"], granularity)
+                key = (tbl, ent["entity_type"])
                 if key not in groups:
                     groups[key] = {
                         **ent,
@@ -2965,54 +2964,6 @@ class OntologyBuilder:
                     logger.warning("Could not add column %s to relationships: %s", col_name, e)
         logger.info("Relationships table %s ready", self.config.fully_qualified_relationships)
 
-    def _purge_stale_bundle_entities(self, current_bundle: str) -> int:
-        """Remove all system-owned entities from a different bundle."""
-        if not current_bundle:
-            return 0
-        esc = current_bundle.replace("'", "''")
-        # DELETE: Remove auto-discovered entities that belong to a DIFFERENT ontology
-        # bundle than the one currently being run.
-        # WHY: When switching bundles (e.g., healthcare -> schema_org), the old
-        # bundle's entity types are no longer relevant. Human-owned entities
-        # (auto_discovered=false) are preserved -- only system-owned are purged.
-        result = self.spark.sql(
-            f"""
-            DELETE FROM {self.config.fully_qualified_entities}
-            WHERE ontology_bundle IS NOT NULL
-              AND ontology_bundle != '{esc}'
-              AND auto_discovered = TRUE
-            """
-        )
-        count = result.first()[0] if result.first() else 0
-        if count:
-            logger.info(f"Purged {count} stale entities from previous bundle")
-        return count
-
-    def _purge_current_bundle_stale(self, granularity: str) -> int:
-        """Delete system-owned entities from the current bundle before a full rebuild.
-
-        Only called in non-incremental mode. Human-owned entities (auto_discovered=false)
-        are preserved. The subsequent MERGE will re-insert freshly discovered entities.
-        """
-        bundle = self.config.ontology_bundle
-        if not bundle:
-            return 0
-        esc = bundle.replace("'", "''")
-        try:
-            result = self.spark.sql(f"""
-                DELETE FROM {self.config.fully_qualified_entities}
-                WHERE auto_discovered = TRUE
-                  AND ontology_bundle = '{esc}'
-                  AND COALESCE(attributes['granularity'], 'table') = '{granularity}'
-            """)
-            count = result.first()[0] if result.first() else 0
-            if count:
-                logger.info("Cleared %d stale %s-granularity entities for full rebuild", count, granularity)
-            return count
-        except Exception as e:
-            logger.debug("Stale entity cleanup skipped: %s", e)
-            return 0
-
     _MIN_STORE_CONFIDENCE = 0.2
 
     def _store_entities(
@@ -3098,7 +3049,6 @@ class OntologyBuilder:
         USING {view_name} AS source
         ON target.entity_name = source.entity_name
            AND array_join(array_sort(target.source_tables), ',') = array_join(array_sort(source.source_tables), ',')
-           AND COALESCE(target.attributes['granularity'], 'table') = COALESCE(source.attributes['granularity'], 'table')
         {match_condition}
             target.confidence = source.confidence,
             target.source_columns = source.source_columns,
@@ -3133,12 +3083,6 @@ class OntologyBuilder:
 
     def discover_and_store_entities(self) -> int:
         """Discover table-level entities, deduplicate, and store."""
-        bundle_name = self.config.ontology_bundle or None
-        if bundle_name:
-            self._purge_stale_bundle_entities(bundle_name)
-            if not self.config.incremental:
-                self._purge_current_bundle_stale("table")
-
         entities = self.discoverer.discover_entities_from_tables()
         if not entities:
             logger.warning(
@@ -3160,8 +3104,6 @@ class OntologyBuilder:
 
     def discover_and_store_column_entities(self) -> int:
         """Discover column-level entities, deduplicate, and store."""
-        if not self.config.incremental and self.config.ontology_bundle:
-            self._purge_current_bundle_stale("column")
         entities = self.discoverer.discover_entities_from_columns()
         if not entities:
             logger.info("No column-level entities discovered")

--- a/tests/test_ontology.py
+++ b/tests/test_ontology.py
@@ -647,6 +647,27 @@ class TestDeduplicateEntities:
         assert result[0]["confidence"] == 0.9
         assert set(result[0]["source_columns"]) == {"col_a", "col_b"}
 
+    def test_merges_across_granularity(self):
+        """ai_batch (no granularity) and column_keyword (granularity=column) should merge."""
+        entities = [
+            {
+                "entity_id": "1", "entity_type": "Patient", "entity_name": "Patient",
+                "source_tables": ["t1"], "source_columns": ["col_a", "col_b"],
+                "attributes": {"discovery_method": "ai_batch"},
+                "confidence": 0.95, "validation_notes": None,
+            },
+            {
+                "entity_id": "2", "entity_type": "Patient", "entity_name": "Patient",
+                "source_tables": ["t1"], "source_columns": ["col_a", "col_c"],
+                "attributes": {"granularity": "column", "discovery_method": "column_keyword"},
+                "confidence": 0.9, "validation_notes": None,
+            },
+        ]
+        result = EntityDiscoverer.deduplicate_entities(entities)
+        assert len(result) == 1
+        assert result[0]["confidence"] == 0.95
+        assert set(result[0]["source_columns"]) == {"col_a", "col_b", "col_c"}
+
     def test_keeps_different_entity_types(self):
         entities = [
             {
@@ -1057,53 +1078,25 @@ class TestPostMergeConfidenceClamp:
         assert "logger.error" in src
 
 
-class TestPurgeStaleBundleEntities:
-    """Tests for _purge_stale_bundle_entities."""
+class TestMultiBundleCoexistence:
+    """Verify that different bundles can coexist in the same output schema."""
 
     @pytest.fixture
     def builder(self):
         mock_spark = MagicMock()
-        config = OntologyConfig(catalog_name="cat", schema_name="sch", ontology_bundle="general")
+        config = OntologyConfig(catalog_name="cat", schema_name="sch", ontology_bundle="fhir_r4")
         with patch.object(OntologyLoader, 'load_config') as mock_load:
             mock_load.return_value = OntologyLoader._default_config()
             b = OntologyBuilder(mock_spark, config)
         return b
 
-    def test_purge_emits_delete_sql(self, builder):
-        mock_result = MagicMock()
-        mock_result.first.return_value = [3]
-        builder.spark.sql.return_value = mock_result
-
-        builder._purge_stale_bundle_entities("general")
-        sql_calls = [c[0][0] for c in builder.spark.sql.call_args_list]
-        delete_sqls = [s for s in sql_calls if "DELETE FROM" in s]
-        assert len(delete_sqls) == 1
-        assert "ontology_bundle != 'general'" in delete_sqls[0]
-        assert "auto_discovered = TRUE" in delete_sqls[0]
-        assert "validated = FALSE" not in delete_sqls[0]
-
-    def test_purge_skips_when_no_bundle(self, builder):
-        count = builder._purge_stale_bundle_entities("")
-        assert count == 0
-        builder.spark.sql.assert_not_called()
-
-    def test_purge_preserves_human_owned_entities(self, builder):
-        """Purge only targets auto_discovered=true; human-owned (auto_discovered=false) survive."""
-        mock_result = MagicMock()
-        mock_result.first.return_value = [0]
-        builder.spark.sql.return_value = mock_result
-
-        builder._purge_stale_bundle_entities("general")
-        sql = builder.spark.sql.call_args[0][0]
-        assert "auto_discovered = TRUE" in sql
-        assert "validated = FALSE" not in sql
-
-    def test_discover_and_store_calls_purge_when_bundle_set(self, builder):
+    def test_discover_does_not_purge_other_bundles(self, builder):
+        """Incremental discover_and_store_entities must not DELETE entities from other bundles."""
         builder.discoverer.discover_entities_from_tables = MagicMock(return_value=[])
         builder.discover_and_store_entities()
         sql_calls = [c[0][0] for c in builder.spark.sql.call_args_list]
         delete_sqls = [s for s in sql_calls if "DELETE FROM" in s]
-        assert len(delete_sqls) == 1
+        assert len(delete_sqls) == 0
 
     def test_discover_and_store_skips_purge_when_no_bundle(self):
         mock_spark = MagicMock()
@@ -1118,11 +1111,10 @@ class TestPurgeStaleBundleEntities:
         assert len(delete_sqls) == 0
 
 
-class TestPurgeCurrentBundleStale:
-    """Tests for _purge_current_bundle_stale (non-incremental full rebuild cleanup)."""
+class TestNoPurgeOnDiscover:
+    """Verify that discover_and_store never issues DELETE, regardless of incremental flag."""
 
-    @pytest.fixture
-    def builder_non_incremental(self):
+    def test_no_delete_when_non_incremental(self):
         mock_spark = MagicMock()
         config = OntologyConfig(
             catalog_name="cat", schema_name="sch",
@@ -1131,40 +1123,13 @@ class TestPurgeCurrentBundleStale:
         with patch.object(OntologyLoader, 'load_config') as mock_load:
             mock_load.return_value = OntologyLoader._default_config()
             b = OntologyBuilder(mock_spark, config)
-        return b
-
-    def test_emits_delete_for_table_granularity(self, builder_non_incremental):
-        b = builder_non_incremental
-        mock_result = MagicMock()
-        mock_result.first.return_value = [5]
-        b.spark.sql.return_value = mock_result
-        b._purge_current_bundle_stale("table")
-        sql = b.spark.sql.call_args[0][0]
-        assert "DELETE FROM" in sql
-        assert "auto_discovered = TRUE" in sql
-        assert "validated = FALSE" not in sql
-        assert "ontology_bundle = 'schema_org'" in sql
-        assert "'table'" in sql
-
-    def test_emits_delete_for_column_granularity(self, builder_non_incremental):
-        b = builder_non_incremental
-        mock_result = MagicMock()
-        mock_result.first.return_value = [3]
-        b.spark.sql.return_value = mock_result
-        b._purge_current_bundle_stale("column")
-        sql = b.spark.sql.call_args[0][0]
-        assert "'column'" in sql
-
-    def test_discover_and_store_calls_purge_when_non_incremental(self, builder_non_incremental):
-        b = builder_non_incremental
         b.discoverer.discover_entities_from_tables = MagicMock(return_value=[])
         b.discover_and_store_entities()
-        sql_calls = [c[0][0] for c in b.spark.sql.call_args_list]
+        sql_calls = [c[0][0] for c in mock_spark.sql.call_args_list]
         delete_sqls = [s for s in sql_calls if "DELETE FROM" in s]
-        current_bundle_deletes = [s for s in delete_sqls if "ontology_bundle = 'schema_org'" in s]
-        assert len(current_bundle_deletes) >= 1
+        assert len(delete_sqls) == 0
 
-    def test_discover_and_store_skips_purge_when_incremental(self):
+    def test_no_delete_when_incremental(self):
         mock_spark = MagicMock()
         config = OntologyConfig(
             catalog_name="cat", schema_name="sch",
@@ -1176,17 +1141,8 @@ class TestPurgeCurrentBundleStale:
         b.discoverer.discover_entities_from_tables = MagicMock(return_value=[])
         b.discover_and_store_entities()
         sql_calls = [c[0][0] for c in mock_spark.sql.call_args_list]
-        current_bundle_deletes = [
-            s for s in sql_calls
-            if "DELETE FROM" in s and "ontology_bundle = 'schema_org'" in s
-        ]
-        assert len(current_bundle_deletes) == 0
-
-    def test_skips_when_no_bundle(self, builder_non_incremental):
-        b = builder_non_incremental
-        b.config.ontology_bundle = None
-        count = b._purge_current_bundle_stale("table")
-        assert count == 0
+        delete_sqls = [s for s in sql_calls if "DELETE FROM" in s]
+        assert len(delete_sqls) == 0
 
 
 # ======================================================================


### PR DESCRIPTION
Both _purge_stale_bundle_entities (cross-bundle) and _purge_current_bundle_stale (same-bundle rebuild) performed blanket DELETEs that destroyed entities for out-of-scope tables when table_names was set. Entity persistence now relies entirely on MERGE upserts.

Also drops granularity from the deduplicate_entities grouping key and the _store_entities MERGE ON clause so that ai_batch and column_keyword entities for the same table+type correctly merge instead of creating duplicates.