### PR TITLE
Add per-table batched metric-view generation

### DIFF
--- a/notebooks/generate_questions.py
+++ b/notebooks/generate_questions.py
@@ -1,0 +1,312 @@
+# Databricks notebook source
+# MAGIC %md
+# MAGIC # Generate Semantic Layer Questions
+# MAGIC
+# MAGIC Auto-generates business questions for the semantic layer and ingests them into
+# MAGIC `semantic_layer_questions`. The semantic layer generator
+# MAGIC (`generate_semantic_layer.py`) produces one metric-view definition per coherent
+# MAGIC question cluster, so this notebook is the entry point that decides *which* tables
+# MAGIC get metric views and *what* they measure.
+# MAGIC
+# MAGIC Reads `table_knowledge_base` + `column_knowledge_base` (populated cheaply by
+# MAGIC `bootstrap_knowledge_bases.py` from live UC comments) and classifies each target
+# MAGIC table's columns into measures / time dimensions / categorical dimensions, then
+# MAGIC emits templated questions. Default path makes **zero LLM calls**; set `use_ai=true`
+# MAGIC to have one AI_QUERY per table refine the questions instead.
+
+# COMMAND ----------
+# MAGIC %pip install -qqqq -r ../requirements.txt
+# MAGIC dbutils.library.restartPython()
+
+# COMMAND ----------
+# MAGIC %md
+# MAGIC ## Parameters
+
+# COMMAND ----------
+
+dbutils.widgets.text("table_names", "", "Comma-separated FQNs or wildcards (e.g. cat.schema.*)")
+dbutils.widgets.text("catalog_name", "", "Catalog holding the KB tables (semantic-layer output)")
+dbutils.widgets.text("schema_name", "", "Schema holding the KB tables (semantic-layer output)")
+dbutils.widgets.text("model_endpoint", "databricks-gpt-oss-120b", "Model Endpoint (only used when use_ai=true)")
+dbutils.widgets.text("questions_per_table", "3", "Questions to emit per table (1-5)")
+dbutils.widgets.dropdown("use_ai", "false", ["false", "true"], "Use AI_QUERY to refine questions")
+
+table_names_raw = dbutils.widgets.get("table_names")
+catalog_name = dbutils.widgets.get("catalog_name")
+schema_name = dbutils.widgets.get("schema_name")
+model_endpoint = dbutils.widgets.get("model_endpoint")
+questions_per_table = max(1, min(5, int(dbutils.widgets.get("questions_per_table") or "3")))
+use_ai = dbutils.widgets.get("use_ai") == "true"
+
+if not table_names_raw or not catalog_name or not schema_name:
+    raise ValueError("table_names, catalog_name, and schema_name are all required")
+
+print(f"KB schema: {catalog_name}.{schema_name}")
+print(f"Targets:   {table_names_raw}")
+print(f"Per table: {questions_per_table}   use_ai: {use_ai}")
+
+# COMMAND ----------
+# MAGIC %md
+# MAGIC ## Resolve target tables
+
+# COMMAND ----------
+
+import sys
+sys.path.append("../src")
+
+from dbxmetagen.processing import expand_schema_wildcards, ensure_fully_scoped_table_names
+
+raw_list = [t.strip() for t in table_names_raw.split(",") if t.strip()]
+expanded = expand_schema_wildcards(raw_list)
+resolved = ensure_fully_scoped_table_names(expanded, catalog_name)
+target_fqns = sorted(set(resolved))
+print(f"Resolved {len(target_fqns)} target tables")
+
+# COMMAND ----------
+# MAGIC %md
+# MAGIC ## Read knowledge bases (scoped to targets)
+# MAGIC
+# MAGIC Mirrors the column set that `SemanticLayerGenerator.build_context()` reads, so the
+# MAGIC questions reference the same metadata the generator will see. `table_name` in both
+# MAGIC KB tables is the fully-qualified `catalog.schema.table`.
+
+# COMMAND ----------
+
+def _sql_in_list(values):
+    return ", ".join("'" + v.replace("'", "''") + "'" for v in values)
+
+if not target_fqns:
+    raise ValueError("No target tables resolved -- nothing to generate questions for.")
+
+_in = _sql_in_list(target_fqns)
+
+tbl_rows = spark.sql(
+    f"SELECT table_name, comment, domain, subdomain "
+    f"FROM {catalog_name}.{schema_name}.table_knowledge_base "
+    f"WHERE table_name IN ({_in})"
+).collect()
+
+col_rows = spark.sql(
+    f"SELECT table_name, column_name, data_type, comment, classification "
+    f"FROM {catalog_name}.{schema_name}.column_knowledge_base "
+    f"WHERE table_name IN ({_in})"
+).collect()
+
+# Convert Spark Rows to plain dicts so downstream code can use dict access AND .get()
+# uniformly (a Row has no .get(), which breaks the AI-prompt path otherwise).
+tbl_rows = [r.asDict() for r in tbl_rows]
+col_rows = [r.asDict() for r in col_rows]
+
+cols_by_table = {}
+for c in col_rows:
+    cols_by_table.setdefault(c["table_name"], []).append(c)
+
+print(f"table_knowledge_base rows: {len(tbl_rows)}   column rows: {len(col_rows)}")
+missing = [t for t in target_fqns if t not in {r['table_name'] for r in tbl_rows}]
+if missing:
+    print(f"WARNING: {len(missing)} target(s) absent from table_knowledge_base "
+          f"(run bootstrap_knowledge_bases.py first): {missing[:5]}")
+
+# COMMAND ----------
+# MAGIC %md
+# MAGIC ## Classify columns
+# MAGIC
+# MAGIC Heuristics align with `build_context()`'s temporal / categorical / numeric hints.
+
+# COMMAND ----------
+
+_NUMERIC_TYPES = ("int", "bigint", "smallint", "tinyint", "double", "float", "decimal", "numeric")
+_MEASURE_KW = ("amount", "amt", "cost", "price", "revenue", "premium", "paid", "allowed",
+               "charge", "total", "count", "cnt", "qty", "quantity", "units", "balance",
+               "spend", "savings", "score")
+_TIME_KW = ("date", "month", "year", "period", "_dt", "report")
+_CATEG_KW = ("type", "status", "state", "category", "code", "flag", "indicator", "group",
+             "line_of_business", "lob", "segment", "class", "level", "region", "name")
+# ETL/audit columns are timestamps but NOT business time dimensions -- exclude them so
+# questions trend on service_date/report_month rather than ingest bookkeeping.
+_AUDIT_KW = ("load", "ingest", "etl", "_loaded", "inserted", "updated_at", "created_at",
+             "_ts", "batch", "source_key", "surrogate", "_scd", "effective_from",
+             "effective_to", "rundate", "run_date", "extract")
+
+
+def _is_numeric(dt):
+    dt = (dt or "").lower()
+    return any(dt.startswith(t) for t in _NUMERIC_TYPES)
+
+
+def _is_audit(name):
+    return any(k in (name or "").lower() for k in _AUDIT_KW)
+
+
+def _is_temporal(dt, name):
+    dt = (dt or "").lower()
+    lname = (name or "").lower()
+    if _is_audit(name):
+        return False
+    return dt.startswith("date") or dt.startswith("timestamp") or any(k in lname for k in _TIME_KW)
+
+
+def classify(columns):
+    measures, time_dims, categ_dims = [], [], []
+    for c in columns:
+        name = (c["column_name"] or "")
+        lname = name.lower()
+        dt = c["data_type"] or ""
+        if _is_audit(name):
+            continue  # ETL/audit columns are not business measures or dimensions
+        if _is_temporal(dt, name):
+            time_dims.append(name)
+        elif _is_numeric(dt) and any(k in lname for k in _MEASURE_KW):
+            measures.append(name)
+        elif any(k in lname for k in _CATEG_KW) and "key" not in lname and "_id" not in lname:
+            categ_dims.append(name)
+    # Fallback: any non-audit numeric column can be a measure if none matched by keyword.
+    if not measures:
+        measures = [c["column_name"] for c in columns
+                    if _is_numeric(c["data_type"]) and not _is_audit(c["column_name"])][:3]
+    return measures, time_dims, categ_dims
+
+# COMMAND ----------
+# MAGIC %md
+# MAGIC ## Build templated questions
+
+# COMMAND ----------
+
+import re
+
+
+def _humanize(token):
+    return re.sub(r"[_\.]+", " ", token or "").strip()
+
+
+def questions_for_table(tbl_row, columns, limit):
+    short = tbl_row["table_name"].split(".")[-1]
+    subject = _humanize(tbl_row["domain"] or "") or _humanize(short)
+    measures, time_dims, categ_dims = classify(columns)
+    out = []
+    m0 = _humanize(measures[0]) if measures else None
+    t0 = _humanize(time_dims[0]) if time_dims else None
+    c0 = _humanize(categ_dims[0]) if categ_dims else None
+    c1 = _humanize(categ_dims[1]) if len(categ_dims) > 1 else None
+
+    def _total(measure):
+        # Avoid "total total ..." when the measure name already implies an aggregate.
+        if any(w in measure.lower() for w in ("total", "count", "sum", "amount", "number")):
+            return measure
+        return f"total {measure}"
+
+    if m0 and t0:
+        out.append(f"What is the {_total(m0)} by {t0} for {subject}?")
+    if m0 and c0:
+        out.append(f"How does {m0} break down by {c0} for {subject}?")
+    if m0 and t0 and c0:
+        out.append(f"What is the trend of {m0} over {t0} segmented by {c0} for {subject}?")
+    if m0 and c1:
+        out.append(f"What is {m0} by {c1} for {subject}?")
+    if len(measures) > 1 and t0:
+        out.append(f"What is the {_total(_humanize(measures[1]))} by {t0} for {subject}?")
+    # Last-resort generic question so every table yields at least one.
+    if not out:
+        out.append(f"What are the key metrics for {subject}?")
+
+    # De-dup while preserving order, then cap.
+    seen, deduped = set(), []
+    for q in out:
+        if q not in seen:
+            seen.add(q)
+            deduped.append(q)
+    return deduped[:limit]
+
+
+templated = {}
+for t in tbl_rows:
+    templated[t["table_name"]] = questions_for_table(t, cols_by_table.get(t["table_name"], []), questions_per_table)
+
+total_templated = sum(len(v) for v in templated.values())
+print(f"Templated {total_templated} questions across {len(templated)} tables")
+for tname, qs in list(templated.items())[:5]:
+    print(f"\n{tname}:")
+    for q in qs:
+        print(f"  - {q}")
+
+# COMMAND ----------
+# MAGIC %md
+# MAGIC ## (Optional) AI refinement
+# MAGIC
+# MAGIC When `use_ai=true`, ask the model to produce sharper questions per table from the
+# MAGIC table comment + column list. One AI_QUERY per table. Falls back to the templated
+# MAGIC questions on any parse failure so the pipeline never stalls.
+
+# COMMAND ----------
+
+questions_by_table = dict(templated)
+
+if use_ai:
+    import json
+    from pyspark.sql.functions import expr
+
+    for t in tbl_rows:
+        tname = t["table_name"]
+        cols = cols_by_table.get(tname, [])
+        col_lines = "; ".join(
+            f"{c['column_name']} ({c['data_type']}): {c.get('comment') or ''}".strip()
+            for c in cols[:60]
+        )
+        prompt = (
+            f"You are a healthcare analytics expert. Given this table, propose "
+            f"{questions_per_table} concise business questions a metric view should answer. "
+            f"Return ONLY a JSON array of strings.\n\n"
+            f"Table: {tname}\nComment: {t.get('comment') or ''}\n"
+            f"Domain: {t.get('domain') or ''} / {t.get('subdomain') or ''}\nColumns: {col_lines}"
+        )
+        prompt_sql = prompt.replace("'", "''")
+        try:
+            resp = spark.sql(
+                f"SELECT ai_query('{model_endpoint}', '{prompt_sql}') AS r"
+            ).collect()[0]["r"]
+            arr = json.loads(resp[resp.index("["): resp.rindex("]") + 1])
+            cleaned = [str(q).strip() for q in arr if str(q).strip()][:questions_per_table]
+            if cleaned:
+                questions_by_table[tname] = cleaned
+        except Exception as e:  # noqa: BLE001 -- best-effort; keep templated fallback
+            print(f"AI refine failed for {tname}: {e} -- keeping templated questions")
+
+# COMMAND ----------
+# MAGIC %md
+# MAGIC ## Ingest into semantic_layer_questions
+
+# COMMAND ----------
+
+from dbxmetagen.semantic_layer import SemanticLayerGenerator, SemanticLayerConfig
+
+config = SemanticLayerConfig(
+    catalog_name=catalog_name,
+    schema_name=schema_name,
+    model_endpoint=model_endpoint,
+)
+gen = SemanticLayerGenerator(spark, config)
+gen.create_tables()
+
+all_questions = [q for qs in questions_by_table.values() for q in qs]
+ingested = gen.ingest_questions(all_questions)
+print(f"Ingested {ingested} questions into {catalog_name}.{schema_name}.semantic_layer_questions")
+
+# COMMAND ----------
+# MAGIC %md
+# MAGIC ## Summary
+
+# COMMAND ----------
+
+display(spark.sql(f"""
+    SELECT status, COUNT(*) AS n
+    FROM {catalog_name}.{schema_name}.semantic_layer_questions
+    GROUP BY status ORDER BY status
+"""))
+
+display(spark.sql(f"""
+    SELECT question_id, question_text, status, created_at
+    FROM {catalog_name}.{schema_name}.semantic_layer_questions
+    WHERE status = 'pending'
+    ORDER BY created_at DESC
+    LIMIT 50
+"""))

--- a/notebooks/generate_semantic_layer_batched.py
+++ b/notebooks/generate_semantic_layer_batched.py
@@ -1,0 +1,196 @@
+# Databricks notebook source
+# MAGIC %md
+# MAGIC # Generate Semantic Layer (Batched, per-table)
+# MAGIC
+# MAGIC The default `generate_semantic_layer` runs ONE two-phase plan over all pending
+# MAGIC questions, and the planner consolidates them into a handful of cross-theme metric
+# MAGIC views (≈5 regardless of how many questions/tables you feed it). That is great for a
+# MAGIC curated semantic layer but does NOT give per-table coverage at scale.
+# MAGIC
+# MAGIC This driver loops over a target table list and, for each table, generates questions
+# MAGIC (reusing `generate_questions`'s AI path), ingests them tagged with `source_table`,
+# MAGIC then calls `generate_metric_views(table_filter=<table>)` so each table yields its own
+# MAGIC view(s). Context is auto-scoped to the table + its FK neighbors, keeping each prompt
+# MAGIC cheap and on-topic.
+# MAGIC
+# MAGIC Cost: one questions AI_QUERY + one plan + N generate AI_QUERY per table. Use
+# MAGIC `max_tables` to cap a smoke run, and `databricks-claude-sonnet-4-6` for quality.
+
+# COMMAND ----------
+# MAGIC %pip install -qqqq -r ../requirements.txt
+# MAGIC dbutils.library.restartPython()
+
+# COMMAND ----------
+
+dbutils.widgets.text("table_names", "", "Comma-separated FQNs or wildcards (e.g. cat.schema.*)")
+dbutils.widgets.text("catalog_name", "", "Catalog holding the KB / semantic-layer tables")
+dbutils.widgets.text("schema_name", "", "Schema holding the KB / semantic-layer tables")
+dbutils.widgets.text("model_endpoint", "databricks-claude-sonnet-4-6", "Model Endpoint")
+dbutils.widgets.text("questions_per_table", "4", "Questions to generate per table (1-6)")
+dbutils.widgets.text("max_tables", "", "Optional cap on number of tables (smoke runs)")
+dbutils.widgets.dropdown("use_ai_questions", "true", ["false", "true"], "AI-refine questions")
+
+table_names_raw = dbutils.widgets.get("table_names")
+catalog_name = dbutils.widgets.get("catalog_name")
+schema_name = dbutils.widgets.get("schema_name")
+model_endpoint = dbutils.widgets.get("model_endpoint")
+questions_per_table = max(1, min(6, int(dbutils.widgets.get("questions_per_table") or "4")))
+max_tables_raw = dbutils.widgets.get("max_tables").strip()
+max_tables = int(max_tables_raw) if max_tables_raw else None
+use_ai_questions = dbutils.widgets.get("use_ai_questions") == "true"
+
+if not table_names_raw or not catalog_name or not schema_name:
+    raise ValueError("table_names, catalog_name, and schema_name are all required")
+
+print(f"KB schema: {catalog_name}.{schema_name}")
+print(f"Model: {model_endpoint}   q/table: {questions_per_table}   use_ai: {use_ai_questions}")
+
+# COMMAND ----------
+# MAGIC %md
+# MAGIC ## Resolve target tables
+
+# COMMAND ----------
+
+import sys
+sys.path.append("../src")
+
+from dbxmetagen.processing import expand_schema_wildcards, ensure_fully_scoped_table_names
+
+raw_list = [t.strip() for t in table_names_raw.split(",") if t.strip()]
+expanded = expand_schema_wildcards(raw_list)
+resolved = ensure_fully_scoped_table_names(expanded, catalog_name)
+target_fqns = sorted(set(resolved))
+if max_tables:
+    target_fqns = target_fqns[:max_tables]
+print(f"Resolved {len(target_fqns)} target tables")
+
+# COMMAND ----------
+# MAGIC %md
+# MAGIC ## Read knowledge bases (scoped to targets)
+
+# COMMAND ----------
+
+def _sql_in_list(values):
+    return ", ".join("'" + v.replace("'", "''") + "'" for v in values)
+
+_in = _sql_in_list(target_fqns)
+
+tbl_rows = [r.asDict() for r in spark.sql(
+    f"SELECT table_name, comment, domain, subdomain "
+    f"FROM {catalog_name}.{schema_name}.table_knowledge_base WHERE table_name IN ({_in})"
+).collect()]
+col_rows = [r.asDict() for r in spark.sql(
+    f"SELECT table_name, column_name, data_type, comment, classification "
+    f"FROM {catalog_name}.{schema_name}.column_knowledge_base WHERE table_name IN ({_in})"
+).collect()]
+
+cols_by_table = {}
+for c in col_rows:
+    cols_by_table.setdefault(c["table_name"], []).append(c)
+tbl_by_name = {t["table_name"]: t for t in tbl_rows}
+print(f"KB: {len(tbl_rows)} tables, {len(col_rows)} columns")
+
+missing = [t for t in target_fqns if t not in tbl_by_name]
+if missing:
+    print(f"WARNING: {len(missing)} target(s) absent from table_knowledge_base "
+          f"(run bootstrap_knowledge_bases.py first): {missing[:5]}")
+
+# COMMAND ----------
+# MAGIC %md
+# MAGIC ## Per-table question generation (AI)
+# MAGIC
+# MAGIC Mirrors `generate_questions.py`'s AI path but scoped to a single table so the
+# MAGIC questions stay table-specific (the batched generator wants per-table questions).
+
+# COMMAND ----------
+
+import json
+
+def ai_questions_for_table(tname):
+    t = tbl_by_name.get(tname, {"table_name": tname})
+    cols = cols_by_table.get(tname, [])
+    col_lines = "; ".join(
+        f"{c['column_name']} ({c['data_type']}): {c.get('comment') or ''}".strip()
+        for c in cols[:60]
+    )
+    prompt = (
+        f"You are a healthcare analytics expert. Given this table, propose "
+        f"{questions_per_table} concise, table-specific business questions a metric view "
+        f"should answer. Favor measurable aggregations and breakdowns over free-text lookups. "
+        f"Return ONLY a JSON array of strings.\n\n"
+        f"Table: {tname}\nComment: {t.get('comment') or ''}\n"
+        f"Domain: {t.get('domain') or ''} / {t.get('subdomain') or ''}\nColumns: {col_lines}"
+    )
+    prompt_sql = prompt.replace("'", "''")
+    resp = spark.sql(f"SELECT ai_query('{model_endpoint}', '{prompt_sql}') AS r").collect()[0]["r"]
+    arr = json.loads(resp[resp.index("["): resp.rindex("]") + 1])
+    return [str(q).strip() for q in arr if str(q).strip()][:questions_per_table]
+
+
+def templated_questions_for_table(tname):
+    # Minimal fallback if AI is off or fails: one generic question keeps the table covered.
+    short = tname.split(".")[-1].replace("_", " ")
+    return [f"What are the key metrics and breakdowns for {short}?"]
+
+# COMMAND ----------
+# MAGIC %md
+# MAGIC ## Batched generation loop
+
+# COMMAND ----------
+
+from dbxmetagen.semantic_layer import SemanticLayerGenerator, SemanticLayerConfig
+
+config = SemanticLayerConfig(
+    catalog_name=catalog_name,
+    schema_name=schema_name,
+    model_endpoint=model_endpoint,
+    validate_expressions=True,   # run dbxmetagen's own autofix before storing
+)
+gen = SemanticLayerGenerator(spark, config)
+gen.create_tables()
+
+totals = {"generated": 0, "validated": 0, "failed": 0}
+per_table = []
+
+for i, tname in enumerate(target_fqns, 1):
+    try:
+        if use_ai_questions:
+            try:
+                qs = ai_questions_for_table(tname)
+            except Exception as e:  # noqa: BLE001
+                print(f"[{i}/{len(target_fqns)}] {tname}: AI questions failed ({e}); using fallback")
+                qs = templated_questions_for_table(tname)
+        else:
+            qs = templated_questions_for_table(tname)
+        if not qs:
+            qs = templated_questions_for_table(tname)
+
+        gen.ingest_questions(qs, source_table=tname)
+        res = gen.generate_metric_views(table_filter=tname)
+        for k in totals:
+            totals[k] += res.get(k, 0)
+        per_table.append((tname, len(qs), res.get("generated", 0),
+                          res.get("validated", 0), res.get("failed", 0)))
+        print(f"[{i}/{len(target_fqns)}] {tname}: {len(qs)} q -> "
+              f"gen={res.get('generated',0)} val={res.get('validated',0)} fail={res.get('failed',0)}")
+    except Exception as e:  # noqa: BLE001 -- one bad table must not abort the batch
+        print(f"[{i}/{len(target_fqns)}] {tname}: ERROR {e}")
+        per_table.append((tname, 0, 0, 0, 0))
+
+print(f"\nBATCH COMPLETE: {totals}")
+
+# COMMAND ----------
+# MAGIC %md
+# MAGIC ## Summary
+
+# COMMAND ----------
+
+display(spark.createDataFrame(
+    per_table, ["source_table", "questions", "generated", "validated", "failed"]
+))
+
+display(spark.sql(f"""
+    SELECT status, COUNT(*) AS n
+    FROM {catalog_name}.{schema_name}.metric_view_definitions
+    GROUP BY status ORDER BY status
+"""))

--- a/resources/jobs/generate_questions.job.yml
+++ b/resources/jobs/generate_questions.job.yml
@@ -1,0 +1,56 @@
+resources:
+  jobs:
+    generate_questions_job:
+      name: "${var.app_name}_generate_questions"
+
+
+      email_notifications:
+        on_failure:
+          - ${var.current_user}
+
+      parameters:
+        - name: catalog_name
+          default: ${var.catalog_name}
+        - name: schema_name
+          default: ${var.schema_name}
+        - name: model_endpoint
+          default: "databricks-gpt-oss-120b"
+        - name: table_names
+          default: ""
+        - name: questions_per_table
+          default: "3"
+        - name: use_ai
+          default: "false"
+
+      tasks:
+        - task_key: generate_questions
+          max_retries: 1
+          job_cluster_key: generate_questions_cluster
+          notebook_task:
+            notebook_path: ../../notebooks/generate_questions.py
+            base_parameters:
+              catalog_name: "{{job.parameters.catalog_name}}"
+              schema_name: "{{job.parameters.schema_name}}"
+              model_endpoint: "{{job.parameters.model_endpoint}}"
+              table_names: "{{job.parameters.table_names}}"
+              questions_per_table: "{{job.parameters.questions_per_table}}"
+              use_ai: "{{job.parameters.use_ai}}"
+          libraries:
+            - whl: ../../dist/*.whl
+
+      job_clusters:
+        - job_cluster_key: generate_questions_cluster
+          new_cluster:
+            policy_id: ${var.policy_id}
+            spark_version: 17.3.x-cpu-ml-scala2.13
+            node_type_id: ${var.node_type}
+            data_security_mode: SINGLE_USER
+            num_workers: 1
+            # --- Uncomment for AWS ---
+            # aws_attributes:
+            #   first_on_demand: 1
+            #   availability: SPOT_WITH_FALLBACK
+            # --- Uncomment for Azure ---
+            # azure_attributes:
+            #   first_on_demand: 1
+            #   availability: SPOT_WITH_FALLBACK_AZURE

--- a/resources/jobs/semantic_layer_batched.job.yml
+++ b/resources/jobs/semantic_layer_batched.job.yml
@@ -1,0 +1,65 @@
+resources:
+  jobs:
+    semantic_layer_batched_job:
+      name: "${var.app_name}_semantic_layer_batched"
+
+      # Per-table metric-view generation. Unlike semantic_layer_job (one plan over all
+      # questions -> ~5 themed views), this loops the target tables and generates one or
+      # more metric views PER table, scoping each prompt to that table + its FK neighbors.
+      # Generation runs dbxmetagen's own expression autofix (validate_expressions=True);
+      # apply / committed-YAML conversion is handled downstream by the dpa-table-metadata
+      # converter, not here.
+
+      email_notifications:
+        on_failure:
+          - ${var.current_user}
+
+      parameters:
+        - name: table_names
+          default: ${var.job_table_names}
+        - name: catalog_name
+          default: ${var.catalog_name}
+        - name: schema_name
+          default: ${var.schema_name}
+        - name: model_endpoint
+          default: "databricks-claude-sonnet-4-6"
+        - name: questions_per_table
+          default: "4"
+        - name: max_tables
+          default: ""
+        - name: use_ai_questions
+          default: "true"
+
+      tasks:
+        - task_key: generate_semantic_layer_batched
+          max_retries: 1
+          job_cluster_key: semantic_layer_batched_cluster
+          notebook_task:
+            notebook_path: ../../notebooks/generate_semantic_layer_batched.py
+            base_parameters:
+              table_names: "{{job.parameters.table_names}}"
+              catalog_name: "{{job.parameters.catalog_name}}"
+              schema_name: "{{job.parameters.schema_name}}"
+              model_endpoint: "{{job.parameters.model_endpoint}}"
+              questions_per_table: "{{job.parameters.questions_per_table}}"
+              max_tables: "{{job.parameters.max_tables}}"
+              use_ai_questions: "{{job.parameters.use_ai_questions}}"
+          libraries:
+            - whl: ../../dist/*.whl
+
+      job_clusters:
+        - job_cluster_key: semantic_layer_batched_cluster
+          new_cluster:
+            policy_id: ${var.policy_id}
+            spark_version: 17.3.x-cpu-ml-scala2.13
+            node_type_id: ${var.node_type}
+            data_security_mode: SINGLE_USER
+            num_workers: 1
+            # --- Uncomment for AWS ---
+            # aws_attributes:
+            #   first_on_demand: 1
+            #   availability: SPOT_WITH_FALLBACK
+            # --- Uncomment for Azure ---
+            # azure_attributes:
+            #   first_on_demand: 1
+            #   availability: SPOT_WITH_FALLBACK_AZURE

--- a/src/dbxmetagen/semantic_layer.py
+++ b/src/dbxmetagen/semantic_layer.py
@@ -638,10 +638,21 @@ class SemanticLayerGenerator:
                 question_text STRING,
                 status STRING,
                 created_at TIMESTAMP,
-                processed_at TIMESTAMP
+                processed_at TIMESTAMP,
+                source_table STRING
             ) COMMENT 'Business questions for semantic layer generation'
         """
         )
+        # Backfill the source_table column on questions tables created by an earlier
+        # version; no-op when the column already exists. Enables per-table batched
+        # generation via generate_metric_views(table_filter=...).
+        try:
+            self.spark.sql(
+                f"ALTER TABLE {fq(self.config.questions_table)} "
+                f"ADD COLUMNS (source_table STRING)"
+            )
+        except Exception:  # noqa: BLE001 -- column already present on a fresh CREATE
+            pass
         self.spark.sql(
             f"""
             CREATE TABLE IF NOT EXISTS {fq(self.config.definitions_table)} (
@@ -666,37 +677,56 @@ class SemanticLayerGenerator:
     # Question ingestion
     # ------------------------------------------------------------------
 
-    def ingest_questions(self, questions: List[str]) -> int:
-        """Insert business questions as ``pending`` rows. Returns number ingested."""
+    def ingest_questions(self, questions: List[str], source_table: Optional[str] = None) -> int:
+        """Insert business questions as ``pending`` rows. Returns number ingested.
+
+        When ``source_table`` is given it is recorded on each row so generation can be
+        scoped per table via ``generate_metric_views(table_filter=...)``. The column list
+        is written explicitly so the optional value lands in the right column regardless
+        of physical table column order.
+        """
         fq_table = self.config.fq(self.config.questions_table)
         now = datetime.utcnow().isoformat()
+        st = source_table.replace(chr(39), chr(39) * 2) if source_table else None
+        st_sql = f"'{st}'" if st else "NULL"
         rows = []
         for q in questions:
             q = q.strip()
             if not q:
                 continue
             rows.append(
-                f"('{uuid.uuid4()}', '{q.replace(chr(39), chr(39)*2)}', 'pending', '{now}', NULL)"
+                f"('{uuid.uuid4()}', '{q.replace(chr(39), chr(39)*2)}', 'pending', '{now}', NULL, {st_sql})"
             )
         if not rows:
             return 0
         values = ", ".join(rows)
         # INSERT: Bulk-append pending semantic-layer questions into the configured questions Delta table with freshly minted
         # question_id (UUID) PKs; fills question_text (escaped single-quote duplication),
-        # status='pending', created_at (UTC ISO); processed_at left NULL until generation completes.
+        # status='pending', created_at (UTC ISO); processed_at left NULL until generation completes;
+        # source_table optionally tags each row for per-table batched generation.
         # WHY: Seeds the semantic-layer pipeline queue so downstream LLM generation can pick only unanswered rows.
         # TRADEOFFS: Bulk INSERT VALUES is fast/low JDBC chatter versus iterative executesSQL—but escapes rely on
         # deterministic sanitisation alone (risk vs parameterized ROW constructors/MERGE); no UPSERT so callers must dedupe upstream question texts manually if uniqueness matters.
-        self.spark.sql(f"INSERT INTO {fq_table} VALUES {values}")
-        logger.info("Ingested %d questions", len(rows))
+        self.spark.sql(
+            f"INSERT INTO {fq_table} "
+            f"(question_id, question_text, status, created_at, processed_at, source_table) "
+            f"VALUES {values}"
+        )
+        logger.info("Ingested %d questions (source_table=%s)", len(rows), source_table or "-")
         return len(rows)
 
     # ------------------------------------------------------------------
     # Context building
     # ------------------------------------------------------------------
 
-    def build_context(self) -> str:
-        """Assemble metadata context from knowledge bases and optional upstream tables."""
+    def build_context(self, focus_table: Optional[str] = None) -> str:
+        """Assemble metadata context from knowledge bases and optional upstream tables.
+
+        When ``focus_table`` is given, the per-table catalog section is narrowed to that
+        table plus any tables it shares an FK relationship with (so cross-table joins are
+        still possible), instead of dumping all KB tables into every prompt. This keeps
+        per-table batched generation cheap and on-topic.
+        """
         fq = self.config.fq
         parts: list[str] = []
 
@@ -731,6 +761,18 @@ class SemanticLayerGenerator:
             f" AND (is_fk IS NULL OR is_fk = TRUE)"
         )
         self._fk_rows = fk_rows
+
+        # Scope to the focus table + its FK neighbors when generating per table.
+        if focus_table:
+            focus_set = {focus_table}
+            for fk in fk_rows:
+                if fk["src_table"] == focus_table:
+                    focus_set.add(fk["dst_table"])
+                elif fk["dst_table"] == focus_table:
+                    focus_set.add(fk["src_table"])
+            tables = [t for t in tables if t["table_name"] in focus_set]
+            fk_rows = [fk for fk in fk_rows
+                       if fk["src_table"] in focus_set and fk["dst_table"] in focus_set]
 
         # Ontology: primary entities per table
         ont_rows = self._safe_collect(
@@ -979,7 +1021,7 @@ class SemanticLayerGenerator:
     # AI generation
     # ------------------------------------------------------------------
 
-    def generate_metric_views(self) -> Dict[str, Any]:
+    def generate_metric_views(self, table_filter: Optional[str] = None) -> Dict[str, Any]:
         """Generate metric view YAML definitions from pending business questions.
 
         Reads pending questions, gathers catalog context (KB comments, FK
@@ -988,15 +1030,25 @@ class SemanticLayerGenerator:
         join columns, optionally dry-runs ``CREATE VIEW`` for validation, and
         persists rows to ``metric_view_definitions``. Returns summary dict with
         counts of generated, validated, and failed views.
+
+        When ``table_filter`` is given (a fully-qualified ``catalog.schema.table``),
+        only pending questions tagged with that ``source_table`` are processed, and the
+        catalog context is narrowed to that table plus its FK neighbors. This is the
+        lever for per-table batched generation: two-phase planning otherwise consolidates
+        ALL pending questions into a handful of cross-theme views, so to get per-table
+        coverage the caller ingests + generates one table at a time.
         """
         fq = self.config.fq
 
-        # Read pending questions
+        # Read pending questions (optionally scoped to one source table for batching)
+        where = "status = 'pending'"
+        if table_filter:
+            where += f" AND source_table = '{table_filter.replace(chr(39), chr(39) * 2)}'"
         q_rows = self.spark.sql(
-            f"SELECT question_id, question_text FROM {fq(self.config.questions_table)} WHERE status = 'pending'"
+            f"SELECT question_id, question_text FROM {fq(self.config.questions_table)} WHERE {where}"
         ).collect()
         if not q_rows:
-            logger.warning("No pending questions found")
+            logger.warning("No pending questions found%s", f" for {table_filter}" if table_filter else "")
             return {"generated": 0, "validated": 0, "failed": 0}
 
         questions = [r["question_text"] for r in q_rows]
@@ -1005,7 +1057,7 @@ class SemanticLayerGenerator:
 
         with _trace_span("semantic_layer.generate_metric_views") as root_span:
             with _trace_span("build_context") as ctx_span:
-                context = self.build_context()
+                context = self.build_context(focus_table=table_filter)
                 if ctx_span is not None:
                     ctx_span.set_outputs({"context_length": len(context)})
 


### PR DESCRIPTION
## What

Two-phase semantic-layer generation runs a single plan over all pending questions, which the planner consolidates into a handful of cross-theme metric views regardless of how many questions or tables are supplied. This adds an opt-in path to generate metric views one table at a time, yielding per-table coverage at scale.

## Changes

- Add an optional `source_table` argument to `ingest_questions` that tags each question row, with an idempotent `ALTER TABLE ... ADD COLUMNS` backfill for existing questions tables.
- Add a `table_filter` argument to `generate_metric_views` that scopes generation to one source table's pending questions and narrows `build_context` (new `focus_table` argument) to that table plus its FK neighbors.
- Add an auto-question generator notebook (`generate_questions.py`) and job, deriving business questions from the knowledge bases.
- Add a batched driver notebook (`generate_semantic_layer_batched.py`) and job that loop a target table list, generating per-table metric views.

All changes are additive and backward compatible: the default code path (no `source_table`, no `table_filter`) is unchanged.

---

I accept the Contributor License Agreement terms in CONTRIBUTING.md.