### PR TITLE
docs(deploy): restore example.env as a copyable {target}.env template

### DIFF
--- a/example.env
+++ b/example.env
@@ -1,122 +1,53 @@
-# dbxmetagen deploy configuration reference (DOCUMENTATION ONLY)
+# dbxmetagen deploy configuration -- copy this to a per-target env file and edit:
 #
-# NOTE: no tool reads this file. It is a human reference for the bundle variables
-# you can override -- you do NOT source or edit it in place. Put your actual values
-# in variable-overrides.json (see below), or pass them with --var / BUNDLE_VAR_*.
+#   cp example.env dev.env            # (or demo.env / prod.env -- match your -t target)
+#   ./deploy.sh -t dev -p <profile>   # sources dev.env, forwards these as bundle --var
 #
-# Deployment is a plain `databricks bundle deploy` -- there is NO deploy.sh and
-# no {target}.env file. Per-workspace values are supplied as BUNDLE VARIABLES.
+# This file is the copy-and-fill template for the ./deploy.sh route (legacy, fully
+# supported). For the plain-CLI or workspace-UI routes, use a JSON overrides file
+# instead -- variable-overrides.example.json (deploy.sh also honors that if present).
 #
-# Recommended: create a gitignored variable-overrides.json at the path DAB
-# auto-loads for your target -- .databricks/bundle/<target>/variable-overrides.json
-# (a plain repo-root file is NOT picked up). Copy the committed example:
-#
-#   mkdir -p .databricks/bundle/dev
-#   cp variable-overrides.example.json .databricks/bundle/dev/variable-overrides.json
-#   # then edit that file:
-#   {
-#     "catalog_name": "your_catalog",
-#     "schema_name": "metadata_results",
-#     "warehouse_id": "your_warehouse_id"
-#   }
-#
-# Then deploy (bundle deploy does NOT start the app -- bundle run does):
-#   databricks bundle deploy -t dev -p <profile>
-#   databricks bundle run    -t dev -p <profile> dbxmetagen_app
-#   scripts/grant_app_permissions.sh -t dev -p <profile>
-#
-# A DEPRECATED ./deploy.sh still exists: a thin wrapper that just chains the
-# three commands above (for CI that still calls it). It does NOT read a
-# {target}.env file -- config comes from the overrides below. Prefer the three
-# commands directly.
-#
-# For the ADVANCED knobs (cluster policy, serverless budget, run_as SP, app
-# permissions, OBO scopes, lakebase), copy variable-overrides.advanced.example.json.
-#
-# Alternatives to the override file (CLI only -- not available in the workspace UI):
-#   - CLI:  databricks bundle deploy --var "catalog_name=...,schema_name=...,warehouse_id=..."
-#   - Env:  export BUNDLE_VAR_catalog_name=... BUNDLE_VAR_schema_name=... etc.
-# Workspace-UI (Git Folder) deploys: create the override file inside the workspace
-# bundle root -- see docs/MANUAL_DEPLOYMENT.md.
-# The workspace HOST comes from your CLI profile (-p) or the DATABRICKS_HOST env var;
-# it is NOT a bundle variable.
-#
-# Behind a proxy / private PyPI mirror: set UV_INDEX_URL (or UV_EXTRA_INDEX_URL),
-# UV_NATIVE_TLS=1, and/or HTTPS_PROXY in your shell before deploying -- they pass
-# through to the build hook's `uv build` automatically. The app's runtime pip install
-# is platform-managed; see the README "PyPI / uv" section for that caveat.
-#
-# The keys below document what each override means. All are defined in
-# variables.yml / resources/app_variables.yml with defaults; at minimum you
-# need to set the two required (catalog_name, warehouse_id).
+# Notes:
+#  - The workspace HOST is NOT set here -- it comes from your CLI profile (-p).
+#  - Only simple (scalar) values go here. COMPLEX settings -- cluster policy,
+#    run_as service principal, OBO user_api_scopes, app_permissions, Lakebase --
+#    are JSON-only: see variable-overrides.advanced.example.json.
+#  - Behind a proxy / private PyPI mirror, export UV_INDEX_URL (and optionally
+#    UV_NATIVE_TLS=1 / HTTPS_PROXY) before deploying; deploy.sh also auto-bridges a
+#    configured `pip` index-url to uv for the wheel build.
+#  - Full reference for every variable and its default: docs/CONFIGURATION.md.
 
-# --- Required (set these two) ---
-# catalog_name  : Target catalog for metadata results. Defaults to "" so a deploy
-#                 still SUCCEEDS if you forget it -- the app then shows a blocking
-#                 "CATALOG_NAME not set" banner until you set it and redeploy.
-#                 Cannot be none/null/empty in normal use.
-# warehouse_id  : SQL warehouse ID for dashboard queries and DDL execution. Same
-#                 behavior: deploy succeeds but SQL/dashboard features error until set.
-#
-# --- Optional but commonly set ---
-# schema_name   : Target schema. Defaults to metadata_results -- only override
-#                 to write results to a different schema.
-# model         : LLM endpoint used by BOTH jobs and the app (comments, PI, domain,
-#                 agents). Default databricks-claude-sonnet-4-6. Override to use a
-#                 different Foundation Model / provisioned-throughput endpoint.
+# --- Required ---
+# Target catalog for metadata results. (Deploy still succeeds if unset, but the app
+# shows a blocking "CATALOG_NAME not set" banner until you set it and redeploy.)
+catalog_name=your_catalog
+# SQL warehouse ID for dashboard queries and DDL execution.
+warehouse_id=your_warehouse_id
+
+# --- Commonly set ---
+# Target schema. Default: metadata_results.
+schema_name=metadata_results
+# LLM endpoint used by BOTH jobs and the app. Default: databricks-claude-sonnet-4-6.
+# model=databricks-claude-sonnet-4-6
 
 # --- Optional: compute ---
-# node_type            : Job cluster node type. AWS i3.2xlarge (default),
-#                        Azure Standard_D8s_v3, GCP n2-highmem-8.
-# metadata_job_cluster : Complex var = the full classic (ML-runtime) job-cluster
-#                        spec. Policy-free by default. To apply a CLUSTER POLICY,
-#                        override this whole block in variable-overrides.json and
-#                        add policy_id + apply_policy_default_values (see the
-#                        example in databricks.yml). Not a plain string -- the
-#                        v1.8.0+ direct deploy engine rejects an empty policy_id.
-# lakebase_job_cluster : Same, for the graph->Lakebase sync job (non-ML, 1 worker).
-# budget_policy_id     : Serverless budget policy ID for cost attribution
-#                        (empty = none; stays a plain string variable).
+# Job-cluster node type. AWS i3.2xlarge (default) | Azure Standard_D8s_v3 | GCP n2-highmem-8.
+# node_type=i3.2xlarge
+# Serverless budget policy ID (cost attribution on serverless jobs). Empty = none.
+# budget_policy_id=
+# A cluster POLICY is NOT a scalar: override the whole metadata_job_cluster block in
+# the JSON overrides (see variable-overrides.advanced.example.json / databricks.yml).
 
 # --- Optional: app ---
-# app_name           : App display name + job-name prefix. Change to deploy multiple
-#                      instances to one workspace. Default: dbxmetagen-app.
-# app_name_suffix    : Optional suffix appended to the app name + job-name prefix
-#                      (e.g. "-dev", "-team1"). Empty by default (name stays exactly
-#                      app_name -- fully backward compatible). Set it to run SEPARATE
-#                      instances in ONE workspace without them overwriting each
-#                      other's single app resource (e.g. per target: "-dev"/"-demo",
-#                      or per team). The app is a singleton by NAME in a workspace, so
-#                      two deploys sharing a name collide (last deploy wins); a suffix
-#                      makes them distinct.
-# vs_endpoint_name   : Vector Search endpoint name. Default: dbxmetagen-vs.
-# lakebase_catalog        : Lakebase catalog for accelerated GraphRAG graph
-#                           queries (used by sync_graph_lakebase_job).
-#                           Default: dbxmetagen_graphrag.
-# lakebase_instance_name  : Lakebase instance name. Default: dbxmetagen.
-#   NOTE (Lakebase is OPT-IN): `bundle deploy` does NOT create a Lakebase instance --
-#   only the sync_graph_lakebase job is deployed. To use "Lakebase Sync" you must
-#   (1) provision a Lakebase (managed Postgres) instance yourself, (2) attach it to
-#   the app as a database resource so PGHOST is set, and (3) have run the analytics
-#   pipeline (graph_nodes/graph_edges must exist). Until PGHOST is set the app shows
-#   "Using Delta Tables" and the "Lakebase Sync" button is greyed out. The graph and
-#   agents work fine on Delta tables without Lakebase. See roadmap LB-1/LB-2.
-# (A cosmetic header name is NOT a bundle variable -- DAB config.env can't carry an
-#  optionally-empty value. To set one, add a static APP_DISPLAY_NAME entry with a
-#  non-empty value in resources/apps/dbxmetagen_app.yml.)
-# enable_obo         : Use the user's token (OBO) instead of the app SP for user-scoped
-#                      calls at RUNTIME (true/false). Default: false. Scopes are declared
-#                      regardless (see user_api_scopes); this only flips the principal.
-
-# --- Optional: complex variables (JSON only) ---
-# Set all variable-overrides values in .databricks/bundle/<target>/variable-overrides.json
-# (DAB auto-loads that exact path; a repo-root file is NOT picked up). Copy the
-# committed variable-overrides.example.json into that path to start.
-# run_as             : Identity jobs run as. Default: deploying user.
-#                      SP example: {"run_as": {"service_principal_name": "<uuid>"}}
-# user_api_scopes    : OAuth scopes declared on EVERY deploy. Default:
-#                      ["files.files","serving.serving-endpoints","sql.statement-execution","dashboards.genie"].
-#                      Requires the workspace user-token-passthrough feature; override to
-#                      [] to opt out where a workspace lacks it.
-# app_permissions    : Who can open the app UI. Default: [].
-#                      Example: [{"group_name":"account users","level":"CAN_USE"}]
+# Vector Search endpoint name. Default: dbxmetagen-vs.
+# vs_endpoint_name=dbxmetagen-vs
+# App display name + job-name prefix. Default: dbxmetagen-app.
+# app_name=dbxmetagen-app
+# Suffix appended to the app name + job-name prefix, so multiple instances can
+# coexist in one workspace (the app is a singleton by name), e.g. -dev.
+# app_name_suffix=
+# App UI title-bar name (must be non-empty). Default: dbxmetagen.
+# app_display_name=dbxmetagen
+# RUNTIME principal switch: use the user's token (OBO) instead of the app service
+# principal for user-scoped calls. Scopes are declared regardless. Default: false.
+# enable_obo=false


### PR DESCRIPTION
The consolidation had turned example.env into a 122-line documentation-only file (zero KEY=value lines) that also wrongly claimed deploy.sh was deprecated and did not read {target}.env. That broke the long-standing `cp example.env dev.env` flow (a copied file set nothing) and contradicted the actual, supported deploy.sh.

Rewrite it as a lean, sourceable template for the ./deploy.sh route: real assignments for the scalars deploy.sh forwards — required uncommented (catalog_name, warehouse_id, schema_name), the rest commented — with concise inline docs, a note that HOST comes from the CLI profile, and pointers to variable-overrides.advanced.example.json (complex/JSON-only settings) and docs/CONFIGURATION.md (full reference). No content lost: the prose reference lives in CONFIGURATION.md and the proxy/UV_INDEX_URL note is already in the README.

Verified it sources cleanly (set -a; source example.env sets catalog_name/ schema_name/warehouse_id; commented optionals stay unset).

Co-authored-by: Isaac