### PR TITLE
Data-driven ERD key/measure classification + AI_QUERY injection guard + roadmap reconciliation

### DIFF
--- a/apps/dbxmetagen-app/app/api_server.py
+++ b/apps/dbxmetagen-app/app/api_server.py
@@ -121,6 +121,22 @@ _AVAILABLE_MODELS = [
     "databricks-gpt-oss-120b",
 ]
 
+# Serving-endpoint names are a constrained identifier charset (letters, digits,
+# and _ . -). AI_QUERY's first arg is a literal that CANNOT be a bind parameter,
+# so a request-supplied model name is interpolated into SQL -- validate it here
+# to close the injection vector (a quote/paren/space would break out of the
+# quoted literal). Fail loudly rather than silently substituting a default.
+_MODEL_ENDPOINT_RE = re.compile(r"^[A-Za-z0-9_.-]{1,128}$")
+
+
+def _safe_model_endpoint(model: Optional[str]) -> str:
+    """Validate a serving-endpoint name before it is interpolated into AI_QUERY
+    SQL. Returns the name unchanged when safe; raises HTTP 400 otherwise."""
+    name = (model or _LLM_MODEL).strip()
+    if not _MODEL_ENDPOINT_RE.match(name):
+        raise HTTPException(400, detail=f"Invalid model endpoint name: {model!r}")
+    return name
+
 # Background Genie builder tasks: task_id -> {status, stage, result, error, created}
 _genie_tasks: dict[str, dict] = {}
 
@@ -8425,7 +8441,7 @@ def explain_erd_recommendation(req: ErdExplainRequest):
     )
     try:
         rows = execute_sql(
-            f"SELECT AI_QUERY('{model}', :prompt) as response", timeout=120,
+            f"SELECT AI_QUERY('{_safe_model_endpoint(model)}', :prompt) as response", timeout=120,
             parameters=[StatementParameterListItem(name="prompt", value=prompt)],
         )
         raw = rows[0]["response"] if rows else ""
@@ -8830,7 +8846,7 @@ Return ONLY the fixed JSON definition (single object, not array)."""
 
     try:
         rows = execute_sql(
-            f"SELECT AI_QUERY('{model}', :prompt) as response", timeout=120,
+            f"SELECT AI_QUERY('{_safe_model_endpoint(model)}', :prompt) as response", timeout=120,
             parameters=[StatementParameterListItem(name="prompt", value=prompt)],
         )
         response = rows[0]["response"] if rows else ""
@@ -9100,7 +9116,7 @@ def _batch_generate_views(
 
     values_block = ",\n".join(rows_sql)
     batch_sql = (
-        f"SELECT view_name, AI_QUERY('{model}', prompt) AS response "
+        f"SELECT view_name, AI_QUERY('{_safe_model_endpoint(model)}', prompt) AS response "
         f"FROM VALUES\n{values_block}\nAS t(view_name, prompt)"
     )
     timeout = 60 + 120 * min(len(plan_views), 6)
@@ -9372,7 +9388,7 @@ def _run_sl_generation(
         plan_prompt = _build_plan_prompt(questions, context, generation_style=generation_style,
                                          max_views=effective_max, num_eligible=num_eligible,
                                          fact_hint=erd_fact_hint)
-        rows = execute_sql(f"SELECT AI_QUERY('{model}', :prompt) as response", timeout=180,
+        rows = execute_sql(f"SELECT AI_QUERY('{_safe_model_endpoint(model)}', :prompt) as response", timeout=180,
                            parameters=[StatementParameterListItem(name="prompt", value=plan_prompt)])
         plan_response = rows[0]["response"] if rows else ""
         plan_views = []
@@ -9697,7 +9713,7 @@ BUSINESS QUESTIONS:
 {q_block}
 
 Return ONLY a JSON object: {{"covered": [<1-based question indices>], "not_covered": [<1-based question indices>]}}"""
-                cov_rows = execute_sql(f"SELECT AI_QUERY('{model}', :prompt) as response", timeout=60,
+                cov_rows = execute_sql(f"SELECT AI_QUERY('{_safe_model_endpoint(model)}', :prompt) as response", timeout=60,
                                        parameters=[StatementParameterListItem(name="prompt", value=cov_prompt)])
                 cov_resp = cov_rows[0]["response"] if cov_rows else ""
                 coverage = _parse_single_json_safe(cov_resp)

--- a/docs/CONSOLIDATED_ROADMAP.md
+++ b/docs/CONSOLIDATED_ROADMAP.md
@@ -26,24 +26,24 @@ All open work items from every roadmap and plan document, organized by theme. Ea
 |----|------|--------|----------|--------|--------|
 | MG-1 | Chat client garbage fallback on JSON parse failure | DONE | -- | -- | RC 1.1 |
 | MG-2 | PII column-to-table rollup (`compute_table_sensitivity`) | OPEN | P1 | M | RC 1.2 |
-| MG-3 | Hardcoded entity suggestions in semantic layer | OPEN | P2 | S | RC 1.3 |
-| MG-4 | Quality metrics exposed to users | OPEN | P2 | L | RC 1.4 |
+| MG-3 | Entity suggestions in semantic layer — CLOSED (non-issue): already data-driven, not hardcoded (semantic_layer.py:731). | DONE | P2 | S | RC 1.3 |
+| MG-4 | Quality metrics exposed to users — PARTIAL: quality_score exists in schema; not yet exposed to users. | PARTIAL | P2 | L | RC 1.4 |
 | MG-5 | Day-2 re-run lifecycle / `_review_status` tracking | OPEN | P1 | M | RC 1.5 |
 | MG-6 | Structured output vs regex JSON recovery | PARTIAL (v0.10.61) | P2 | M | RC 2.1 |
 | MG-7 | Schema-level PII reconciliation via FK graph | OPEN | P2 | M | RC 2.3 |
-| MG-8 | Ontology as generation context (inject entity type into prompts) | OPEN | P2 | M | RC 2.4 |
-| MG-9 | Audit trail for metadata state transitions | OPEN | P2 | M | RC 2.5 |
-| MG-10 | `enrich_from_knowledge_base()` should override stale UC comments | OPEN | P2 | S | apply_ddl analysis |
+| MG-8 | Ontology as generation context (inject entity type into prompts) — DONE: ontology context injected via enrich_from_ontology() (prompts.py:180-216, called processing.py:2450). | DONE | P2 | M | RC 2.4 |
+| MG-9 | Audit trail for metadata state transitions — DONE: entity_tag_audit_log (ontology.py:3910/4032/4045). | DONE | P2 | M | RC 2.5 |
+| MG-10 | `enrich_from_knowledge_base()` should override stale UC comments — PARTIAL: injects KB but fills EMPTY slots only (prompts.py:244/264); does NOT override stale UC comments (the open part; see KB-2). | PARTIAL | P2 | S | apply_ddl analysis |
 | MG-11 | `MetadataConfig` schema validation (Pydantic model with field validators) | OPEN | P2 | M | code audit |
-| MG-12 | PI prompt: add negative examples for clinical vocabulary | OPEN | P1 | S | PI precision analysis |
-| MG-13 | PI prompt: tighten Presidio deference rule (#10) | OPEN | P1 | S | PI precision analysis |
-| MG-14 | Presidio `diagnosis_code` regex too broad -- raise threshold or gate | OPEN | P2 | S | PI precision analysis |
-| MG-15 | Preserve `type` field downstream instead of collapsing to `protected` | OPEN | P2 | S | PI precision analysis |
-| MG-16 | PI confidence threshold gating (discard low-confidence classifications) | OPEN | P2 | S | PI precision analysis |
+| MG-12 | PI prompt: add negative examples for clinical vocabulary — PARTIAL: positive clinical examples exist; no explicit negative examples. | PARTIAL | P1 | S | PI precision analysis |
+| MG-13 | Tighten Presidio deference rule (#10) — the rule exists (prompts.py:957) but is intentionally loose; make it stricter. | OPEN | P1 | S | PI precision analysis |
+| MG-14 | Presidio `diagnosis_code` regex too broad -- raise threshold or gate — PARTIAL: score_threshold gating exists; diagnosis_code regex still broad (deterministic_pi.py:127). | PARTIAL | P2 | S | PI precision analysis |
+| MG-15 | Preserve `type` field downstream instead of collapsing to `protected` — PARTIAL: type preserved at column level; collapsed to protected only at table level (processing.py:3217). | PARTIAL | P2 | S | PI precision analysis |
+| MG-16 | PI confidence threshold gating (discard low-confidence classifications) — DONE: Presidio score_threshold gating (deterministic_pi.py:158/172). | DONE | P2 | S | PI precision analysis |
 | MG-17 | SWIFT/BIC dropped: `swift`/`iban` patterns were under supported_entity=CREDIT_CARD -> hit the card Luhn gate -> SWIFT (non-numeric) always dropped. Fixed: own recognizers emitting SWIFT_CODE/IBAN_CODE (bypass Luhn). | DONE | P2 | S | UAT PI scenario |
 | MG-18 | UAT PI gold not normalized for equivalent classes (pi/pii, phi/medical_information) | OPEN | P3 | S | UAT PI scenario |
 | FK-11 | Provably-disjoint FK pair (join probe ran, join_matched=0 AND ri_score=0) still scored final_confidence ~0.6. Fixed: collapse final_confidence 0.25x on the same never_joins signal, so it drops below threshold (not just is_fk=false). | DONE | P2 | S | UAT FK scenario (uat_fk_hard region_id trap) |
-| MG-19 | `luhn_checksum(res.score)` in classify_column passes the SCORE (float) not the matched TEXT -> always False -> every deterministic CREDIT_CARD match dropped. Needs matched-text plumbing + presidio to verify (risk: order_ref trap). Not fixed blind. | OPEN | P2 | S | UAT PI scenario (deep-dive during MG-17) |
+| MG-19 | `luhn_checksum(res.score)` in classify_column passes the SCORE (float) not the matched TEXT -> always False -> every deterministic CREDIT_CARD match dropped. Needs matched-text plumbing + presidio to verify (risk: order_ref trap). Not fixed blind. — CONFIRMED bug: luhn_checksum(res.score) passes score not text (deterministic_pi.py:279) → every deterministic CREDIT_CARD match dropped. PRIORITIZE. | OPEN | P1 | S | UAT PI scenario (deep-dive during MG-17) |
 | MG-20 | Special-char table identifiers (e.g. a `$` in a federated Redshift table name like `…1$raw`) break SQL that interpolates the FQN bare -> `PARSE_SYNTAX_ERROR at '$'`. **DONE (v0.10.61-64):** shared `quote_fqn()` (`databricks_utils.py`) backtick-quotes each dotted segment; applied to every customer-source-table SQL site -- profiling, FK source sampling, `extended_metadata` DESCRIBE DETAIL + DESCRIBE CATALOG, `processing.get_column_types_from_describe` (DESCRIBE TABLE), the type-conversion read, DESCRIBE EXTENDED (processing + `prompts.py`). The final gap (the actual data read) was MG-22. **Verified live on `uat_ddl_edges.dollar$raw`:** generation "Table processed" + 4 metadata rows; profiling covers it. `very_wide_table` (120 cols) also clean (242 rows -> ON-19 confirmed). | DONE | P1 | M | Customer log + live UAT |
 | MG-22 | **Silent `$`-table skip (the read path, sub-bug of MG-20).** `read_table_with_type_conversion` read the table via `spark.read.table(fqn)` in the no-special-types branch. `spark.read.table` parses the identifier through the SAME `parseTableIdentifier` as `spark.table()`, so `$` raised `PARSE_SYNTAX_ERROR`; the exception was caught in `get_generated_metadata_data_aware` -> returned `[]` -> `review_and_generate_metadata` -> `(None,None)` -> "Skipped - No metadata generated", yet `mark_table_completed` still ran (control=`completed`, zero metadata rows). An earlier assumption that `spark.read.table` tolerates `$` was WRONG. **DONE (v0.10.64):** route ALL source reads through `spark.sql(f"SELECT * FROM {quote_fqn(name)}")` (parse-safe) -- `read_table_with_type_conversion` (both branches), profiling `_profile_table_delta`/`_federated`, and the override source-col check; corrected the `quote_fqn` docstring. Verified live: `dollar$raw` now processes with 4 metadata rows. Regression scenario `uat_ddl_edges.dollar$raw` + `TestGenerationPathIdentifierQuoting` guard against reintroduction. | DONE | P1 | M | Live UAT (uat_ddl_edges) |
 | MG-21 | Log spam: `[NOTICE] Using a notebook authentication token` repeats ~90x in a single run, burying real errors. **DONE (v0.10.61):** shared `new_workspace_client()` passes `product='dbxmetagen', disable_notice=True` (graceful fallback for older SDKs), routed through the hot-path `chat_client` auth-fallback + secret-fetch sites. Deliberately NOT a shared singleton -- each call gets its own client so concurrent LLM calls don't contend on shared SDK auth/HTTP state (per Eli: singleton would add latency at 50-100+ concurrent calls). | DONE | P3 | S | Customer log |
@@ -69,6 +69,7 @@ what's broken/missing — the current approach works fairly well. Full design:
 | PQ-5 | Role inference + Genie `id_cols` naming reduction (`_infer_role` naming 0.35->0.20 as constants; genie prefer FK/ontology PK signals over `_id` suffix) | DONE | P2 | M | UAT |
 | PQ-6 | Suffix-less + `_code`-not-FK benchmark scenario (`uat_fk_suffixless`) + eval_compare harness extension; the measurement gate for PQ-1 | DONE | P1 | M | UAT |
 | PQ-7 | Bound MV `_validate_expr`/`_yaml_dry_run` federation round-trip counts (LIMIT 0/schema-only, lower sev) | DONE | P3 | S | federation audit |
+| PQ-8 | **Federation validation mode for KPI dry-runs (LIMIT 1 → LIMIT 0).** `_validate_kpi_formula` validates with `SELECT {formula} FROM {table} LIMIT 1`. Since KPI formulas are aggregates, `LIMIT 1` does NOT bound the scan — it computes the aggregate over the whole table, and on a federated source may not push down (full remote scan + transfer). **Bounded to ~1 query/KPI today** by PQ-4's cap(5)+dedup+stop-at-first, so acceptable for now — this is a follow-up, not a blocker. Add a federation-aware mode (foreign/`FOREIGN`/`EXTERNAL` catalog via `_is_federated_catalog`, or `FEDERATION_MODE`) that swaps the probe to `LIMIT 0`. **Reasoning (the whole point):** the only difference is that `LIMIT 0` *skips the actual query to avoid repeated table scans* and validates the *logical plan* instead — the analyzer still fully resolves the formula (column existence, types, aggregate/GROUP BY legality, syntax; all analysis-phase, independent of LIMIT), while Spark's `OptimizeLimitZero` prunes the subtree to an empty `LocalTableScan` so **no rows are scanned or pulled**. Verified on-warehouse: `EXPLAIN … LIMIT 0` → `LocalTableScan <empty>` (billion-row source fully pruned) vs `LIMIT 1` → full `Range` scan + aggregate; and `SUM(bad_col) … LIMIT 0` still errors `UNRESOLVED_COLUMN`. The ONLY thing skipped is data-dependent RUNTIME errors (div/0, cast/overflow on real values) — fragile/time-varying, can false-fail a structurally-valid KPI, and already not checked for metric views (`_validate_expr` is already `LIMIT 0`, per PQ-7). Requires redefining KPI-validation success as "query did not throw" (not row-count based), else `LIMIT 0`'s 0-rows result mislabels every KPI "empty" in `reduce_kpi_validation` (kpi_logic.py). Refs: `_validate_kpi_formula` (api_server.py), `_is_federated_catalog`. | OPEN | P2 | S | federation audit (Eli) |
 
 ### MG-1: Chat client garbage fallback on JSON parse failure
 
@@ -253,7 +254,7 @@ pragmatically).
 | ON-9 | Composite component grouping | DEFERRED | P3 | M | OF 2B |
 | ON-10 | Subdomain -> entity affinity | DEFERRED | P2 | S+M | OF 2C |
 | ON-11 | JSON-LD export -- add column properties + Schema.org mappings | PARTIAL | P2 | M | OF 3A, OE 4 |
-| ON-12 | Bundle version in UC tags | OPEN | P2 | S | OF 3B |
+| ON-12 | Bundle version in UC tags — DONE: bundle version written to UC tags (ontology.py:3943-4009). | DONE | P2 | S | OF 3B |
 | ON-13 | 5GNF trait nodes | KILLED | -- | -- | OE, OF |
 | ON-14 | Row-level instance nodes | KILLED | -- | -- | OE, OF |
 | ON-15 | OWL/TTL import | DEFERRED | P3 | L | OF, OE |
@@ -263,7 +264,7 @@ pragmatically).
 | ON-19 | Batch column classification truncates on WIDE tables: a 144-col table produced an 11424-char response cut off at `max_tokens=4096` -> invalid/partial JSON. The `len(columns) <= n*1.25` remainder-merge (n=120 -> up to 150 cols in ONE call) sent oversized batches, and truncation wasn't detected as truncation. **DONE (v0.10.61):** replaced count-merge with output-token-budget chunking (`_COLS_PER_CLASSIFY_CHUNK=60`), raised `max_tokens` 4096->8192, and `_classify_column_chunk_resilient` recursively BISECTS on `StructuredTruncationError` (ai_query only as last resort on a single column) so no column is lost. | DONE | P1 | M | Customer log (wide biotech tables) |
 | ON-20 | Empty/`{}` responses (`Expecting value: line 1 column 1`; `classifications Field required`) parse-failed with no finish-reason context, so a retryable empty/truncated response looked identical to genuine garbage. **DONE (v0.10.61)** with MG-6: `invoke_structured` now reads `finish_reason` and raises `StructuredTruncationError` (length) or `StructuredEmptyResponseError` (empty/`{}`) -- both `ValueError` subclasses (backward compatible) -- and logs finish_reason + length. This is the signal ON-19/ON-21 bisect on. | DONE | P2 | S | Customer log |
 | ON-21 | **geo_classifier has the SAME truncation bug as ON-19, worse**: `max_tokens=2048`, called `with_structured_output` directly (no fallback), and SILENTLY defaulted every column to non_geographic on any failure -> wide tables mis-classified with no error. **DONE (v0.10.61):** routed through `invoke_structured` (gains truncation signal), output-token chunking (`_GEO_COLS_PER_CHUNK=60`), `max_tokens` 2048->8192, and `_classify_geo_chunk_resilient` bisects on truncation -- defaulting only as a true last resort on a single column. | DONE | P1 | S | ON-19 sibling audit |
-| ON-22 | **Table-scope ontology relationship reads (two-bundles-per-schema, different table sets).** Confirmed real customer config: multiple ontology bundles coexisting in ONE output schema on DIFFERENT table sets (finance/commercial/life-sciences data + their own ontologies in one `metadata_results`). Bundle is a PROVENANCE tag, not a scoping key. Storage is already correct; entities/FKs/joins are already table-scoped. **LOW severity, cosmetic:** ontology relationships are consumed as DESCRIPTIVE TEXT ONLY (`context.py:993,1053`; `semantic_layer.py:766-768`) — NOT joins (those come from `fk_predictions`, table-scoped, intentionally cross-bundle) — so a shared entity-type name (both bundles have `Organization`) only bleeds a wrong descriptive relationship line across table sets. **Fix (table-keyed, never bundle-keyed):** (a) reuse existing `evidence_table` to require the originating table be in scope; (b) add nullable `source_tables` to `ontology_relationships` for bundle-defined rows. Structural cross-ontology integration (FK/joins across table sets) MUST be preserved — ON-22 does not touch it. Extends ON-18; multi-schema UI-swap/enterprise-connect are EN-1/EN-2. | OPEN | P2 | M | Customer ask (Mohit/Eli) + multi-bundle consumer audit |
+| ON-22 | **Table-scope ontology relationship reads (two-bundles-per-schema, different table sets).** Confirmed real customer config: multiple ontology bundles coexisting in ONE output schema on DIFFERENT table sets (finance/commercial/life-sciences data + their own ontologies in one `metadata_results`). Bundle is a PROVENANCE tag, not a scoping key. Storage is already correct; entities/FKs/joins are already table-scoped. **LOW severity, cosmetic:** ontology relationships are consumed as DESCRIPTIVE TEXT ONLY (`context.py:993,1053`; `semantic_layer.py:766-768`) — NOT joins (those come from `fk_predictions`, table-scoped, intentionally cross-bundle) — so a shared entity-type name (both bundles have `Organization`) only bleeds a wrong descriptive relationship line across table sets. **Fix (table-keyed, never bundle-keyed):** (a) reuse existing `evidence_table` to require the originating table be in scope; (b) add nullable `source_tables` to `ontology_relationships` for bundle-defined rows. Structural cross-ontology integration (FK/joins across table sets) MUST be preserved — ON-22 does not touch it. Extends ON-18; multi-schema UI-swap/enterprise-connect are EN-1/EN-2. — PARTIAL: multi-bundle infra DONE (table-scoped storage/sweep/edges); remaining = consumer-side evidence_table filtering (genie/context.py:507, semantic_layer.py:714) + a source_tables column on ontology_relationships. | PARTIAL | P2 | M | Customer ask (Mohit/Eli) + multi-bundle consumer audit |
 
 ### ON-4: Remove legacy `link` SQL filter
 
@@ -484,7 +485,7 @@ upsert with provenance, then let the existing graph/VS builders consume it.
 | SL-1 | **MV definition read-back parser.** Read a deployed MV's YAML body from UC (`information_schema.views.view_definition` / DESCRIBE) and parse it into the internal `json_definition` shape -- the inverse of `metric_view_core._serialize_to_yaml`. Must tolerate constructs dbxmetagen never emits (hand-authored YAML). This is the core new primitive everything else depends on. | OPEN | P2 | L | Reverse-sync feature |
 | SL-2 | **Provenance + drift columns on `metric_view_definitions`.** Add `source_origin` (`dbxmetagen`/`external_import`/`external_edit`), `deployed_owner`, `last_synced_at`, and a drift flag. Analogous to `graph_edges.source_system` + entity `auto_discovered`. Lets graph/VS attribute sources and lets re-generation avoid clobbering imported defs. | OPEN | P2 | S | Reverse-sync feature |
 | SL-3 | **Reconcile pass (exact match).** For each UC MV, match on `metric_view_name` + `deployed_catalog.deployed_schema` (name is unique within a UC schema; a *different owner* is the SAME object -> record owner, don't fork). Import unknown MVs as `source_origin=external_import`. **Authority: UC is truth for imports; for a dbxmetagen-authored MV edited outside, do NOT silently overwrite the stored def -- flag drift for review** (mirrors the `review_updated_at` steward-lock). Never destructive. | OPEN | P2 | M | Reverse-sync feature |
-| SL-4 | **Sync imported/updated MVs to the three consumers.** Once SL-3 upserts a definition, drive `semantic_graph` (metric_view/measure/dimension nodes+edges) and `vector_index` (`metadata_documents` + VS) off it -- reuse existing builders; add MV `source_origin` attribution to nodes/docs. Confirm `merge_edges`/doc sweeps treat imported MVs like any other source (no orphan/clobber). | OPEN | P2 | M | Reverse-sync feature |
+| SL-4 | **Sync imported/updated MVs to the three consumers.** Once SL-3 upserts a definition, drive `semantic_graph` (metric_view/measure/dimension nodes+edges) and `vector_index` (`metadata_documents` + VS) off it -- reuse existing builders; add MV `source_origin` attribution to nodes/docs. Confirm `merge_edges`/doc sweeps treat imported MVs like any other source (no orphan/clobber). — PARTIAL: graph-sync infra exists (api_server.py:15253+); upstream reconcile (SL-3) missing; VS-index sync not implemented. | PARTIAL | P2 | M | Reverse-sync feature |
 | SL-5 | **Fuzzy 'possibly-related' suggestions (NOT auto-merge).** Same source table + measure/dimension overlap but a DIFFERENT name is surfaced as a review-UI suggestion only -- never auto-merged into one node (auto-merge risks collapsing two genuinely-distinct views / corrupting the graph). Preserves the human-in-the-loop contract. | OPEN | P3 | M | Reverse-sync feature |
 | SL-6 | **Drift dashboard / review surface.** Show UC MVs missing from the graph, dbxmetagen MVs whose deployed YAML has drifted from the stored def, and orphaned graph/VS entries for MVs deleted in UC. The human decides import/overwrite/ignore per row. | OPEN | P3 | M | Reverse-sync feature |
 
@@ -513,21 +514,21 @@ preserved).
 
 | ID | Item | Status | Priority | Effort | Source |
 |----|------|--------|----------|--------|--------|
-| DE-1 | Batch log writes (per-table single-row Delta writes) | OPEN | P2 | S | RC DE-1 |
-| DE-2 | Parallelize DDL execution (sequential collect-then-loop) | OPEN | P1 | M | RC DE-2 |
+| DE-1 | Batch log writes (per-table single-row Delta writes) — DONE: batched Delta append (processing.py:188). | DONE | P2 | S | RC DE-1 |
+| DE-2 | Parallelize DDL execution (sequential collect-then-loop) — PARTIAL: column comments batch per-table on DBR 16.3+; table-level DDL still sequential. | PARTIAL | P1 | M | RC DE-2 |
 | DE-3 | Remove redundant DataFrame materializations | OPEN | P1 | S | RC DE-3 |
 | DE-6 | Error messages fed as metadata into LLM prompts | DONE | -- | -- | RC DE-6 |
-| DE-7a | Triple materialization in `write_ddl_df_to_volume` | OPEN | P2 | S | RC DE-7 |
-| DE-7b | Dead temp view + unused var in `sample_values()` | OPEN | P2 | S | RC DE-7 |
-| DE-7c | Unused constant `JOIN_SAMPLE_SIZE` | OPEN | P2 | S | RC DE-7 |
+| DE-7a | Triple materialization in `write_ddl_df_to_volume` — DONE. | DONE | P2 | S | RC DE-7 |
+| DE-7b | Dead temp view + unused var in `sample_values()` — DONE. | DONE | P2 | S | RC DE-7 |
+| DE-7c | Unused constant `JOIN_SAMPLE_SIZE` — DONE (constant removed). | DONE | P2 | S | RC DE-7 |
 | DE-8 | Codebase-wide `.collect()` audit (~232 calls, 21 files) | OPEN | P3 | L | RC DE-8 |
 
 ### 5b. Full Pipeline Performance (Ontology, FK, Extended Metadata)
 
 | ID | Item | Status | Priority | Effort | Source |
 |----|------|--------|----------|--------|--------|
-| DE-4 | FK prediction collect-then-loop (700+ sequential SQL) | OPEN | P1 | L | RC DE-4 |
-| DE-5 | DESCRIBE DETAIL in for-loop with hard cap at 100 | OPEN | P2 | M | RC DE-5 |
+| DE-4 | FK prediction collect-then-loop (700+ sequential SQL) — PARTIAL: batch sampling + concurrent RI checks added; not fully vectorized. | PARTIAL | P1 | L | RC DE-4 |
+| DE-5 | DESCRIBE DETAIL is per-table now (extended_metadata.py:413), not a 100-capped loop — original framing stale; verify no batching/rate-limit needed. | OPEN | P2 | M | RC DE-5 |
 
 ### 5c. Scaling Recommendations
 
@@ -567,11 +568,11 @@ preserved).
 
 | ID | Item | Status | Priority | Effort | Source |
 |----|------|--------|----------|--------|--------|
-| AQ-1 | Batch column classification (O(NC) -> O(N)) | OPEN | P1 | M | AQ 1 |
+| AQ-1 | Batch column classification (O(NC) -> O(N)) — PARTIAL: chunked by columns_per_call (O(N/chunk)); not a single AI_QUERY call. | PARTIAL | P1 | M | AQ 1 |
 | AQ-2 | Batch table classification (O(N) -> O(N/20)) | OPEN | P1 | M | AQ 2 |
-| AQ-3 | Raise FK AI threshold (0.3 -> 0.5+) | OPEN | P2 | S | AQ 3 |
+| AQ-3 | Raise FK AI threshold (0.3 -> 0.5+) — DONE: FK AI threshold already 0.7 (fk_prediction.py:227), above the 0.5 target. | DONE | P2 | S | AQ 3 |
 | AQ-4 | Vectorized SQL AI_QUERY for ontology | OPEN | P2 | L | AQ 4 |
-| AQ-5 | Async/concurrent Python LLM calls | OPEN | P2 | M | AQ 5 |
+| AQ-5 | Async/concurrent Python LLM calls — PARTIAL: async classify_table_domain_async() exists (domain_classifier.py:888) but not wired into the pipeline. | PARTIAL | P2 | M | AQ 5 |
 
 ### 5e. Graph Edge Quality
 
@@ -585,8 +586,9 @@ preserved).
 
 | ID | Item | Status | Priority | Effort | Source |
 |----|------|--------|----------|--------|--------|
-| DE-9 | God-module decomposition (`api_server.py` 9.8K lines, `ontology.py` 5.3K, `processing.py` 4K) | OPEN | P2 | L | code audit |
+| DE-9 | God-module decomposition (`api_server.py` **16.1K** lines, `ontology.py` 5.3K, `processing.py` 4K) — FULL decomposition; see DE-11 for the minimal enabling subset to do first. | OPEN | P2 | L | code audit |
 | DE-10 | Dependency injection for testability (7+ internal module stubs required to test `processing.py`) | OPEN | P2 | L | code audit |
+| DE-11 | **Minimal `api_server.py` split (prep/enabler — do FIRST).** api_server.py is 16.1K lines / ~190 endpoints and forces serialization of any workstream that touches it (DP-13, EN-1, SLG-1). Behavior-preserving minimal split (NOT the full DE-9): (1) extract the shared foundation into a `_common.py` — `execute_sql`/`execute_sql_meta`, `fq`, `CATALOG`/`SCHEMA`, `get_workspace_client`, the TTL caches+locks, model config, error regexes, `_MAX_RESULT_ROWS`; (2) move the two largest cohesive route groups (candidates by size: ontology 40, semantic-layer 39, genie 21 — pick the two with the LOWEST shared-state coupling at spec time) into `routers/*.py` as FastAPI `APIRouter`s wired via `app.include_router()`. No endpoint paths or behavior change. Acceptance: the registered-route set (`app.routes` paths) is IDENTICAL before/after (add a test asserting this), app boots, core suite green. Removes ~79 endpoints from api_server.py and unblocks parallel workstreams. Scoped subset of DE-9. | OPEN | P1 | M | workstream enabler (Eli) |
 
 ### 5g. Pipeline Incrementality (May 2026)
 
@@ -635,8 +637,8 @@ These survived verification against the code (F3 SQL-skeleton-dedup was checked 
 
 | ID | Item | Status | Priority | Effort | Source |
 |----|------|--------|----------|--------|--------|
-| CR-1 | **Loose distinctive-format regexes** (`profiling.py`): `NPI_PATTERN=^\d{10}$` matches any 10-digit number (phone/account/order id); `CUSIP_PATTERN=^[0-9A-Z]{9}$` matches any 9-char code (SKU). Both feed the relaxed 0.30 value-overlap containment bar, so unrelated same-shape columns can bucket together and emit spurious FK candidates. MITIGATED today by the parent-uniqueness gate + join probe + never_joins veto, so precision impact is bounded, not zero. Fix: tighten (NPI checksum / NDC-style segmenting; treat CUSIP as advisory) or require ontology/name corroboration before applying the relaxed bar to `npi`/`cusip`. | OPEN | P2 | S | Code review (Isaac) |
-| CR-2 | **Truncation detection only in the fallback path** (`chat_client.invoke_structured`): the `finish_reason=='length'` -> `StructuredTruncationError` classification lives only in the `except` branch; the primary `with_structured_output(...).invoke()` path returns directly with no finish_reason check. A tool-calling endpoint that returns a truncated-but-parseable structure without raising would bypass ON-19's bisect. In practice the batch-classify endpoints fall through to the JSON branch (so ON-19 works there), but this isn't universal. Fix: inspect finish_reason on the primary path too (where the SDK surfaces it). | OPEN | P2 | S | Code review (Isaac) |
+| CR-1 | **Loose distinctive-format regexes** (`profiling.py`): `NPI_PATTERN=^\d{10}$` matches any 10-digit number (phone/account/order id); `CUSIP_PATTERN=^[0-9A-Z]{9}$` matches any 9-char code (SKU). Both feed the relaxed 0.30 value-overlap containment bar, so unrelated same-shape columns can bucket together and emit spurious FK candidates. MITIGATED today by the parent-uniqueness gate + join probe + never_joins veto, so precision impact is bounded, not zero. Fix: tighten (NPI checksum / NDC-style segmenting; treat CUSIP as advisory) or require ontology/name corroboration before applying the relaxed bar to `npi`/`cusip`. — CONFIRMED loose (profiling.py:70/72). PRIORITIZE. | OPEN | P1 | S | Code review (Isaac) |
+| CR-2 | **Truncation detection only in the fallback path** (`chat_client.invoke_structured`): the `finish_reason=='length'` -> `StructuredTruncationError` classification lives only in the `except` branch; the primary `with_structured_output(...).invoke()` path returns directly with no finish_reason check. A tool-calling endpoint that returns a truncated-but-parseable structure without raising would bypass ON-19's bisect. In practice the batch-classify endpoints fall through to the JSON branch (so ON-19 works there), but this isn't universal. Fix: inspect finish_reason on the primary path too (where the SDK surfaces it). — PARTIAL: truncation detection exists but only in the fallback path, not the primary tool-calling path. | PARTIAL | P2 | S | Code review (Isaac) |
 | CR-3 | **`StructuredEmptyResponseError` never specially handled** downstream: it's raised on an empty/`{}` completion but only `StructuredTruncationError` is caught in geo/ontology; empty falls to the generic fallback, so its documented "retryable transient empty" intent is unrealized (not broken -- the fallback still returns a result). Fix: catch it for one bare retry before defaulting. | OPEN | P3 | S | Code review (Isaac) |
 | CR-4 | **O(n^2) value-overlap bucket loop** (`fk_prediction.get_value_overlap_candidates`): the nested `i x j` over each `(dtype-family, pattern)` bucket does set-intersections for every ordered pair; the `emitted >= ceiling` break bounds ACCEPTED candidates, not the rejected-pair work (the common case). A wide schema with hundreds of `numeric_id` columns in one bucket runs the full n^2 on the driver. Fix: pre-filter bucket members (e.g. require compatible distinct-count ranges / a MinHash prefilter) or cap bucket size before the pairwise loop. | OPEN | P2 | M | Code review (Isaac) |
 | CC-1 | **customer-context re-seed MERGE clobbered `created_by`.** The MATCHED branch set `tgt.created_by = src.created_by` (always `'yaml_seed'`) + `tgt.scope`/`tgt.scope_type`, contradicting the adjacent comment ("updates only text/label/priority + updated_at") and resetting UI-set operator provenance on every re-seed. **DONE (v0.10.65):** MATCHED branch now updates only `context_text`/`context_label`/`priority`/`updated_at` (scope/scope_type are derived from the `context_id` key so invariant); test extended to assert `tgt.created_by` is absent from the MERGE. | DONE | P3 | S | Code review (Isaac) |
@@ -693,7 +695,6 @@ These survived verification against the code (F3 SQL-skeleton-dedup was checked 
 |----|------|--------|----------|--------|
 | T3-1 | SQL injection via f-strings | LOW RISK | P3 | RC 3.1 |
 | T3-2 | Sequential processing within a task | ADDRESSED | -- | RC 3.2 |
-| T3-3 | MetadataReview component decomposition | OPEN | P3 | RC 2.2 |
 | T3-4 | TypeScript migration | NICE-TO-HAVE | P3 | RC 3.6 |
 | T3-5 | React Router | NICE-TO-HAVE | P3 | RC 3.6 |
 | T3-6 | Multi-person approval workflow | ENTERPRISE | P3 | RC 3.7 |
@@ -729,12 +730,11 @@ Recommended gate before promoting: one live backward-compat smoke test (feature 
 
 | ID | Item | Status | Priority | Effort | Source |
 |----|------|--------|----------|--------|--------|
-| EN-1 | Runtime metadata-result-schema selection in the app (schema picker; make `fq()`/`CATALOG`/`SCHEMA` request-scoped instead of startup globals — ~28 call sites; caches keyed by schema). Top customer ask. Builds on `schema_name` filter params + per-MV `deployed_catalog`/`deployed_schema` precedent. | OPEN | P1 | L | Customer ask (Mohit) |
-| EN-2 | Cross-schema semantic-layer stitching at enterprise level (schema registry + federated/union reads across `metadata_results` schemas + cross-schema entity/FK disambiguation). Design-spike first. Depends on EN-1. | OPEN | P2 | L | Customer ask (Mohit) |
-| EN-3 | External context sources for the agent — a structured UC table or an EXTERNAL vector index (already-ingested data; NOT reaching out to SharePoint). Index/endpoint are hardwired to `{CATALOG}.{SCHEMA}.{VS_INDEX_SUFFIX}` today; add `EXTERNAL_VECTOR_INDEXES`/`EXTERNAL_KB_TABLES` config + union into retrieval with source attribution. | OPEN | P2 | M | Customer ask (Mohit) |
-| EN-4 | Review-only user role (review + save/apply in Review-and-Apply only). No role system today — OBO identity only. Add role context + `require_role` gate on write/generation endpoints + frontend nav hiding. Relates to T3-6. | OPEN | P2 | M | Customer ask (Mohit) |
-| EN-5 | Read-only deployment mode (`READ_ONLY_MODE` central write gate over KB PATCH / apply-ddl / ontology+tag apply / job submit; document restricted-SP fallback). `federation_mode`/`apply_ddl` exist but there is no centralized gate. Shares plumbing with EN-4. | OPEN | P2 | M | Customer ask (Mohit) |
-| EN-6 | Production-readiness — a DEFINED MINIMUM BAR, not an open epic (see detail for the 5-point checklist + explicit punt list). Bar: API test suite in CI (`test_app_logic.py` excluded, `pyproject.toml:54`; + TG-1..TG-6), OBO trust-boundary documented + guardrail, graceful-degradation verified, ops monitors + auth/action audit log (MG-9), read-only mode (EN-5) available. PUNTED (not prod-blockers): god-module split (DE-9), DI refactor (DE-10), rate limiting, full pagination, full RBAC. Open Q gates size: self-hosted vs managed offering. | OPEN | P1 | M | Customer ask (Mohit) + code audit |
+| EN-1 | Runtime metadata-result-schema selection in the app (schema picker; make `fq()`/`CATALOG`/`SCHEMA` request-scoped instead of startup globals — ~28 call sites; caches keyed by schema). Top customer ask. Builds on `schema_name` filter params + per-MV `deployed_catalog`/`deployed_schema` precedent. — PRIORITIZED this cycle. | OPEN | P1 | L | Customer ask (Mohit) |
+| EN-2 | Cross-schema semantic-layer stitching at enterprise level (schema registry + federated/union reads across `metadata_results` schemas + cross-schema entity/FK disambiguation). Design-spike first. Depends on EN-1. — FOLDED into EV-* (Enterprise Unified View); see new EV section. | OPEN | P2 | L | Customer ask (Mohit) |
+| EN-3 | External context sources for the agent — a structured UC table or an EXTERNAL vector index (already-ingested data; NOT reaching out to SharePoint). Index/endpoint are hardwired to `{CATALOG}.{SCHEMA}.{VS_INDEX_SUFFIX}` today; add `EXTERNAL_VECTOR_INDEXES`/`EXTERNAL_KB_TABLES` config + union into retrieval with source attribution. — FOLDED into CTX-3 (agent-side external context). | OPEN | P2 | M | Customer ask (Mohit) |
+| EN-4 | Review-only user role (review + save/apply in Review-and-Apply only). No role system today — OBO identity only. Add role context + `require_role` gate on write/generation endpoints + frontend nav hiding. Relates to T3-6. — DEFERRED: OBO+UC already enforce per-user data security; in-app roles are lower marginal value. | OPEN | P3 | M | Customer ask (Mohit) |
+| EN-5 | Restricted / no-job-execution mode (DISABLE_JOB_EXECUTION) — gate the run-a-job endpoints (metadata gen, analytics pipeline, sync). Rationale: jobs run under their configured run_as (SP/owner) regardless of OBO, so OBO does NOT stop a viewer from launching SP-privileged compute; 'read-only' really means 'no job execution' (optionally also gate in-app writes). Absorbs EN-6's read-only intent. | OPEN | P2 | M | Customer ask (Mohit) |
 
 ### EN-1: Runtime metadata-result-schema selection
 
@@ -777,39 +777,41 @@ central write gate. **Work:** `READ_ONLY_MODE` env flag gating all write endpoin
 apply-ddl(+bundle), ontology/tag apply, job submit) → 403 with a clear message; document the
 restricted-service-principal fallback. Shares the enforcement point with EN-4. **Files:** `apps/.../api_server.py`.
 
-### EN-6: Production-readiness (defined minimum bar)
+### EN-6 (removed)
 
-**Status: OPEN** -- "Production-ready" is defined here as an explicit acceptance bar so it cannot
-become an open-ended sink. Most of it is documentation + wiring existing pieces, not new architecture.
+REMOVED (decomposed): production-readiness epic split into — API test suite → a QA item; audit log → MG-9 (done); OBO trust-boundary → a small doc item; read-only → EN-5. Not tracked as one epic.
 
-**Minimum bar (the actual gate) — 5 dimensions:**
-1. **Security/auth:** document the OBO trust boundary — the app trusts `x-forwarded-access-token`, which
-   is safe ONLY behind Databricks Apps ingress and must never be exposed directly; confirm the app SP
-   is least-privilege; secrets/PII never logged (already enforced). Mostly docs + one guardrail.
-2. **Reliability/correctness:** the API test suite runs in CI (`test_app_logic.py` is excluded today,
-   `pyproject.toml:54`) + API-route tests (TG-1..TG-6); no unbounded client loops (one class fixed
-   this session — see the `execute_sql_meta` pagination guard); graceful degradation on a dependency
-   outage verified (VS-down → UC-Delta fallback already exists).
-3. **Operability:** the two ops monitors (`notebooks/monitors/job_activity_monitor.py`,
-   `pipeline_health_check.py`) wired/documented; structured logging (log-spam already fixed, MG-21); a
-   basic **auth/action audit log** (MG-9) so "who applied what" is answerable.
-4. **Data safety:** review-before-apply (exists), steward-lock preservation (exists), and read-only
-   mode (EN-5) available for cautious rollouts.
-5. **Deployability:** backward-compat verified (done this session), single deploy path (done), clear
-   versioning/rollback.
+---
 
-**Explicitly PUNTED (do NOT gate prod-ready on these):** `api_server.py` god-module split (DE-9) and
-DI refactor (DE-10) are dev-velocity, not prod blockers — deferring them is the biggest scope-saver;
-rate limiting, full result pagination, cost dashboards (P3 hardening); full RBAC (EN-4's cheap
-reviewer flag suffices for the customer).
+## Enterprise Unified View (EV) — cross-schema stitching across multiple dbxmetagen OUTPUT schemas
 
-**Open question that sets the true size:** production-ready for a **customer self-hosting the app in
-their own workspace** (mostly: document boundaries + tests + audit — bounded M) vs **us running it as a
-managed multi-tenant offering** (adds tenant isolation, rate limiting, SLOs — much larger). The row's
-`M` assumes self-hosted; managed is a separate, larger scope.
+| ID | Item | Status | Priority | Effort | Source |
+|----|------|--------|----------|--------|--------|
+| EV-1 | Output-schema registry — system-of-record table + app config listing registered metadata_results schemas (catalog.schema, domain, owner, last_run). Foundation the rest reads. | OPEN | P2 | M | Enterprise (Eli) |
+| EV-2 | Federated vector retrieval — agent queries MULTIPLE per-schema VS indexes at once; fan-out + reciprocal-rank-fusion merge; results schema-attributed. | OPEN | P2 | M | Enterprise (Eli) |
+| EV-3 | A2A orchestrator over per-schema metadata agents — orchestrator routes a question to domain/schema-specialized agents and aggregates with provenance. | OPEN | P2 | L | Enterprise (Eli) |
+| EV-4 | Enterprise KB union — union/federated view over per-schema table_knowledge_base + metadata_documents, keyed by the EV-1 registry. | OPEN | P2 | M | Enterprise (Eli) |
+| EV-5 | Enterprise knowledge-graph overlay — merge per-schema graph_nodes/edges with cross-schema entity resolution (link entity::X across schemas) + inter-schema edges. | OPEN | P2 | L | Enterprise (Eli) |
+| EV-6 | Cross-schema FK/relationship discovery — candidate pairs spanning schemas (cross-domain joins), registry-gated. | OPEN | P2 | M | Enterprise (Eli) |
+| EV-7 | Verify + harden cross-schema metric-view / Genie assembly (reportedly partly works already) — make explicit, guard, and test. | OPEN | P3 | S | Enterprise (Eli) |
 
-Cross-links TG-1..TG-6, DE-9/DE-10, MG-9, MG-21, EN-5, and the tracked scaling items R3/R4/R5/R6.
-**Files:** `pyproject.toml`, `apps/.../api_server.py`, `tests/`, docs.
+*Sequencing: EV-1 → (EV-2, EV-4) → (EV-3, EV-5, EV-6); EV-7 standalone.*
+
+---
+
+## New Feature & Quality Backlog (this cycle)
+
+| ID | Item | Status | Priority | Effort | Source |
+|----|------|--------|----------|--------|--------|
+| CTX-1 | External-context layer: design/architect ingesting/consolidating/indexing an external source (VS index, volume, table, or schema) into a queryable context store with a clean access API. Foundation. | OPEN | P2 | L | Eli |
+| CTX-2 | Generation-side consumption of CTX-1 — wire external context into comment/PI/domain/FK prompts (extends existing enrich_from_ontology / enrich_from_knowledge_base hooks). | OPEN | P2 | M | Eli |
+| CTX-3 | Agent-side consumption of CTX-1 — retrieval agents (metadata research, analyst) query the context layer. Absorbs former EN-3. | OPEN | P2 | M | Eli |
+| KB-2 | Sync EXISTING UC comments into the knowledge base (ingest, not generate). Complements MG-10 (which only fills empty slots). | OPEN | P2 | M | Eli |
+| FK-2 | Explicit FK hints from a user-supplied JSON/dtype file — seed/boost/lock FK candidate generation. | OPEN | P2 | M | Eli |
+| PROF-2 | Federation-safe profiling correctness — current profiling is often wrong and unguarded on federated sources (no federation guard in _fetch_column_stats_concurrent prompts.py:490 = R3a; caps hardcoded profiling.py:82 = R9). Fix accuracy while bounding federated scans (pushdown-friendly stats / bounded sample / clean skip). | OPEN | P1 | M | Eli |
+| AGT-1 | Metadata research agent: add MLflow tracing + reduce token consumption, preserving effectiveness. | OPEN | P2 | M | Eli |
+| SLG-1 | Semantic-layer knowledge-graph de-dup correctness — graph node dedup currently keys on node_id = definition_id+name (api_server.py:15438), NOT source/filter; fix so same-name/different-expression measures are distinguished and identical measures across defs can merge. | OPEN | P2 | M | Eli |
+| UX-2 | Button tooltips/explanations (e.g. the Sync button) across the app UI. | OPEN | P3 | S | Eli |
 
 ---
 

--- a/src/dbxmetagen/erd_recommender.py
+++ b/src/dbxmetagen/erd_recommender.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import json
 import math
+import re
 from dataclasses import dataclass, field, asdict
 from typing import Any, Optional
 
@@ -146,35 +147,103 @@ def _looks_like_mart(short: str) -> bool:
     return any(kw in short for kw in _MART_KEYWORDS)
 
 
-# Column-name semantics: disambiguate a high-cardinality numeric that is an
-# identifier (a grain/PK) from one that is a continuous MEASURE. Profiling flags
-# both as `is_unique_candidate`, so name is what tells `instrument_revenue`
-# (a measure) apart from `account_id` (a key). Used by _grain_column /
-# _measurable_columns so a measure is never mistaken for the grain and vice versa.
-_KEY_SUFFIXES = ("_id", "_key", "_guid", "_uuid", "_sk", "_pk", "_fk", "_code", "_no", "_num", "_nbr")
-_MEASURE_KEYWORDS = (
-    "revenue", "amount", "amt", "total", "count", "cnt", "qty", "quantity", "price",
-    "cost", "sum", "avg", "average", "balance", "volume", "spend", "value", "rate",
+# Key-vs-measure discrimination is DATA-DRIVEN, never name-based -- column-name
+# conventions don't generalize across schemas, so DATA decides everything it
+# can, in priority order:
+#   1. FK PARTICIPATION (`key_hints`): a column that joins is a key, whatever it
+#      is called. Primary, fully schema-agnostic signal.
+#   2. TYPE + UNIQUENESS, for the ambiguous case -- a unique numeric with NO FK
+#      evidence, where profiling alone can't tell a surrogate key from a
+#      continuous measure (both are `is_unique_candidate`). A CONTINUOUS numeric
+#      (float/double/decimal) is a measure even when unique; a unique INTEGER is
+#      an identifier.
+#   3. NAME, as a MILD tiebreaker ONLY where the data is genuinely silent -- a
+#      unique numeric whose `data_type` is unknown (thin/federated profiling).
+#      The lexical prior is a weak nudge, never a gate: it cannot override FK
+#      participation or a clear continuous/integer type, and defaults to
+#      "identifier" when the name is uninformative.
+# `data_type` is profiling's readable type string, e.g. "long", "integer",
+# "double", "decimal(18,2)", "string" (Spark type name, lower-cased).
+_CONTINUOUS_NUMERIC_PREFIXES = ("double", "float", "decimal", "numeric", "real")
+_INTEGER_NUMERIC_PREFIXES = (
+    "int", "integer", "long", "bigint", "short", "smallint", "byte", "tinyint",
 )
 
+# Weak lexical priors (token-based, not substring, so "account" never matches
+# "count"). Used only as a tiebreaker per rule 3 above and to lightly order grain
+# candidates -- deliberately small; missing a term just means "no hint", not a
+# wrong answer.
+_KEY_NAME_TOKENS = frozenset((
+    "id", "key", "code", "guid", "uuid", "sk", "pk", "num", "no", "nbr", "number",
+))
+_MEASURE_NAME_TOKENS = frozenset((
+    "amount", "amt", "total", "qty", "quantity", "price", "cost", "revenue",
+    "sales", "balance", "count", "sum", "avg", "rate", "value", "volume", "spend",
+))
 
-def _looks_like_key(name: Optional[str], key_hints: Optional[set] = None) -> bool:
-    """True when a column name reads like an identifier / join key (or is one of
-    the table's actual FK columns)."""
-    if not name:
+
+def _is_continuous_numeric(data_type: Optional[str]) -> bool:
+    """True for fractional numeric types (a continuous MEASURE shape)."""
+    if not data_type:
         return False
-    n = name.lower()
-    if key_hints and n in key_hints:
+    return data_type.strip().lower().startswith(_CONTINUOUS_NUMERIC_PREFIXES)
+
+
+def _is_integer_numeric(data_type: Optional[str]) -> bool:
+    """True for integer numeric types (an identifier/surrogate-key shape)."""
+    if not data_type:
+        return False
+    return data_type.strip().lower().startswith(_INTEGER_NUMERIC_PREFIXES)
+
+
+def _name_hint(name: Optional[str]) -> Optional[str]:
+    """A MILD lexical prior: 'key' | 'measure' | None from name tokens. A weak
+    tiebreaker only -- callers must let FK/type signals win first. Token-based
+    (split on non-alphanumerics, trailing plural 's' stripped) so it never fires
+    on a substring (e.g. "account" is not "count")."""
+    if not name:
+        return None
+    key_hit = measure_hit = False
+    for tok in re.split(r"[^a-z0-9]+", name.lower()):
+        if not tok:
+            continue
+        base = tok[:-1] if tok.endswith("s") and len(tok) > 1 else tok
+        if tok in _KEY_NAME_TOKENS or base in _KEY_NAME_TOKENS:
+            key_hit = True
+        if tok in _MEASURE_NAME_TOKENS or base in _MEASURE_NAME_TOKENS:
+            measure_hit = True
+    if key_hit == measure_hit:      # neither, or ambiguous both -> no signal
+        return None
+    return "key" if key_hit else "measure"
+
+
+def _is_key_like(col: dict, key_hints: Optional[set] = None) -> bool:
+    """Data-driven: is this column an identifier / join key (not a measure)?
+
+    Priority: FK participation (`key_hints`) wins outright; otherwise a column
+    must be near-unique to be a key at all. Among unique columns, TYPE decides
+    where it can -- a continuous numeric (e.g. a high-precision amount) is a
+    measure even if unique, a unique integer/string/date is an identifier -- and
+    only when the type is UNKNOWN does the mild name prior (`_name_hint`) break
+    the tie, defaulting to identifier."""
+    name = (col.get("column_name") or "").lower()
+    if key_hints and name in key_hints:
         return True
-    return n == "id" or n.endswith(_KEY_SUFFIXES)
-
-
-def _looks_like_measure(name: Optional[str]) -> bool:
-    """True when a column name reads like a continuous/additive measure."""
-    if not name:
+    is_unique = (
+        bool(col.get("is_unique_candidate"))
+        or float(col.get("cardinality_ratio") or 0.0) >= PK_UNIQUENESS_MIN
+    )
+    if not is_unique:
         return False
-    n = name.lower()
-    return any(kw in n for kw in _MEASURE_KEYWORDS)
+    if col.get("has_numeric_stats"):
+        dt = col.get("data_type")
+        if _is_continuous_numeric(dt):
+            return False            # continuous numeric = measure (type wins)
+        if _is_integer_numeric(dt):
+            return True             # integer + unique = identifier (type wins)
+        # Type is silent -> mild name prior breaks the tie; default to identifier.
+        return _name_hint(name) != "measure"
+    return True                     # unique non-numeric (string/date) = key
 
 
 def _coerce_list(val: Any) -> list:
@@ -243,11 +312,12 @@ def _build_edges(fk_rows: list[dict]) -> list[ErdEdge]:
     return edges
 
 
-def _measurable_columns(profiling_rows: list[dict]) -> list[str]:
-    """Numeric, low-null columns that make good measures. A near-unique numeric
-    is only treated as an ID (and skipped) when its NAME looks like a key -- a
-    measure-named high-cardinality numeric (e.g. `instrument_revenue`) is still a
-    measure, not a key."""
+def _measurable_columns(profiling_rows: list[dict], key_hints: Optional[set] = None) -> list[str]:
+    """Numeric, low-null columns that make good measures. A column is dropped only
+    when it is KEY-LIKE (`_is_key_like`): it participates in an FK, or it is a
+    unique non-continuous numeric (a surrogate/natural key). A unique CONTINUOUS
+    numeric (e.g. a high-precision amount) stays a measure. This is symmetric with
+    `_grain_column`, so the two never disagree, and it is name-independent."""
     out = []
     for c in profiling_rows or []:
         if not c.get("has_numeric_stats"):
@@ -258,24 +328,28 @@ def _measurable_columns(profiling_rows: list[dict]) -> list[str]:
         name = c.get("column_name")
         if not name:
             continue
-        # A near-unique numeric is usually an ID -- but only when its name reads
-        # like a key. Otherwise a continuous measure would be wrongly dropped.
-        if c.get("is_unique_candidate") and _looks_like_key(name):
+        # A key/identifier is not a measure. Continuous numerics are never keys
+        # (see _is_key_like), so a unique amount/price is correctly kept here.
+        if _is_key_like(c, key_hints):
             continue
         out.append(name)
     return out
 
 
 def _grain_column(profiling_rows: list[dict], key_hints: Optional[set] = None) -> Optional[str]:
-    """Best natural-key candidate: unique + low null, but NEVER a measure and with
-    a strong preference for id/key-named columns (and the table's actual FK
-    columns). A high-cardinality continuous measure like `instrument_revenue` is
-    unique + low-null too, so uniqueness alone must not win -- name semantics
-    decide, otherwise a measure gets mislabeled the grain (which also poisons role
-    inference via the 'has key, few measures -> dimension' nudge)."""
-    # rank: 2 = key-named / FK column, 1 = non-numeric key candidate, 0 = numeric
+    """Best identifier/grain candidate, chosen from DATA not names: unique + low
+    null and NOT a continuous-numeric measure. A high-cardinality continuous
+    measure is unique + low-null too, so uniqueness alone must not win -- type
+    tells them apart (`_is_key_like`), otherwise a measure gets mislabeled the
+    grain (which also poisons role inference via the 'has key, few measures ->
+    dimension' nudge). Ranking prefers FK-participating columns, then non-numeric
+    keys (natural keys/codes), then integer identifiers, with a MILD name nudge
+    among equals; ties break on cardinality."""
+    # rank: 2 = FK column, 1 = non-numeric key candidate, 0 = integer identifier.
+    # +0.5 name nudge lets an id-named candidate edge out an unnamed peer of the
+    # same structural rank -- ordering only, it excludes nothing.
     best = None
-    best_key: tuple = (-1, -1.0)  # (name_rank, cardinality_ratio)
+    best_key: tuple = (-1.0, -1.0)  # (rank, cardinality_ratio)
     for c in profiling_rows or []:
         name = c.get("column_name")
         if not name:
@@ -285,16 +359,17 @@ def _grain_column(profiling_rows: list[dict], key_hints: Optional[set] = None) -
         is_unique = bool(c.get("is_unique_candidate")) or ratio >= PK_UNIQUENESS_MIN
         if not (is_unique and low_null):
             continue
-        is_numeric = bool(c.get("has_numeric_stats"))
-        # A measure-named column is never the grain, even if it happens to be unique.
-        if _looks_like_measure(name) and is_numeric and not _looks_like_key(name, key_hints):
+        # A continuous numeric is a measure, never the grain.
+        if not _is_key_like(c, key_hints):
             continue
-        if _looks_like_key(name, key_hints):
-            rank = 2
-        elif not is_numeric:
-            rank = 1
+        if key_hints and name.lower() in key_hints:
+            rank = 2.0
+        elif not c.get("has_numeric_stats"):
+            rank = 1.0
         else:
-            rank = 0
+            rank = 0.0
+        if _name_hint(name) == "key":
+            rank += 0.5
         cand = (rank, ratio)
         if cand > best_key:
             best_key = cand
@@ -344,7 +419,7 @@ def _infer_role(
     # 3. Profiling shape (naming-independent -- this is what lets an unlabeled
     #    mart / wide table be classified sensibly).
     grain = _grain_column(profiling_rows, key_hints)
-    measures = _measurable_columns(profiling_rows)
+    measures = _measurable_columns(profiling_rows, key_hints)
     n_measures = len(measures)
     n_cols = len(profiling_rows)
     if grain and n_measures <= 1:
@@ -534,7 +609,7 @@ def recommend_erd(
             role=role,
             confidence=conf,
             reasons=reasons,
-            measurable_columns=_measurable_columns(prof),
+            measurable_columns=_measurable_columns(prof, hints),
             grain=_grain_column(prof, hints),
         ))
 
@@ -568,11 +643,15 @@ def recommend_erd(
         anchor_nodes = [n for n in nodes if n.role in ("fact", "source", "bridge")]
     no_clear_anchor = False
     if not anchor_nodes:
-        # No structural signal at all. Do NOT default to "every table is a fact"
-        # (the old bug that reported N fact tables for an all-dimension schema);
-        # anchor only on tables that at least have measures.
+        # No structural fact/source/bridge signal at all. Do NOT invent anchors:
+        # neither from every table (the old bug that reported N fact tables / N
+        # views for an all-dimension schema) nor from every measurable table
+        # (that just re-degenerates to one-view-per-table). Leave anchors empty --
+        # the count collapses to a single starter view (base = max(0, 1)) and any
+        # disconnected measurable table still earns the diminishing orphan bump
+        # below, so we never approach the raw table count.
         no_clear_anchor = True
-        anchor_nodes = [n for n in nodes if n.measurable_columns] or list(nodes)
+        anchor_nodes = []
     anchors = [n.table for n in anchor_nodes]
     anchor_set = {t.lower() for t in anchors}
 

--- a/tests/test_erd_recommender.py
+++ b/tests/test_erd_recommender.py
@@ -17,6 +17,10 @@ from dbxmetagen.erd_recommender import (
     _recommend_view_count,
     _grain_column,
     _measurable_columns,
+    _is_key_like,
+    _is_continuous_numeric,
+    _is_integer_numeric,
+    _name_hint,
     ErdRecommendation,
     GenSufficiency,
     FK_CONFIRMED_MIN,
@@ -35,10 +39,20 @@ def _fk(src_t, src_c, dst_t, dst_c, conf=0.9, is_fk=False, **kw):
     return row
 
 
-def _num_col(name, null_rate=0.0, unique=False):
+def _num_col(name, null_rate=0.0, unique=False, data_type="double"):
+    # data_type drives key-vs-measure: continuous (double/decimal) -> measure even
+    # when unique; integer -> identifier when unique. Default continuous (a measure).
     return {"column_name": name, "has_numeric_stats": True,
             "null_rate": null_rate, "is_unique_candidate": unique,
-            "cardinality_ratio": 1.0 if unique else 0.3}
+            "cardinality_ratio": 1.0 if unique else 0.3,
+            "data_type": data_type}
+
+
+def _int_id_col(name, data_type="bigint"):
+    """A unique integer identifier column (surrogate/natural key shape)."""
+    return {"column_name": name, "has_numeric_stats": True,
+            "null_rate": 0.0, "is_unique_candidate": True,
+            "cardinality_ratio": 1.0, "data_type": data_type}
 
 
 def _key_col(name):
@@ -536,3 +550,119 @@ class TestFanoutDetection:
                             profiling_by_table={"c.s.fct_orders": [_num_col("amount")]})
         assert len(rec.sufficiency.fanout_warnings) == 1
         assert "fan out" in rec.sufficiency.fanout_warnings[0]
+
+
+class TestKeyMeasureIsDataDrivenNotNameBased:
+    """Key-vs-measure classification must generalize across ALL schemas: it comes
+    from FK participation + type/uniqueness, NEVER from column-name vocabulary.
+    These tests deliberately use names a naming heuristic would get WRONG."""
+
+    def test_type_helpers(self):
+        assert _is_continuous_numeric("double") is True
+        assert _is_continuous_numeric("decimal(18,2)") is True
+        assert _is_continuous_numeric("float") is True
+        assert _is_continuous_numeric("bigint") is False
+        assert _is_integer_numeric("bigint") is True
+        assert _is_integer_numeric("int") is True
+        assert _is_integer_numeric("double") is False
+        # Unknown/absent type: neither -- callers fall back conservatively.
+        assert _is_continuous_numeric(None) is False
+        assert _is_integer_numeric("") is False
+
+    def test_continuous_numeric_is_a_measure_even_with_a_key_like_name(self):
+        # Named like an id, but a unique DECIMAL -> a measure, not a key. A
+        # name-suffix rule would wrongly call this a key.
+        rows = [_num_col("transaction_id", unique=True, data_type="decimal(18,2)")]
+        assert "transaction_id" in _measurable_columns(rows)
+        assert _grain_column(rows) is None      # a measure is never the grain
+
+    def test_integer_unique_is_an_identifier_even_with_a_measure_like_name(self):
+        # Named like a measure ("revenue_key"), but a unique BIGINT -> identifier.
+        # A keyword rule ("revenue") would wrongly call this a measure.
+        rows = [_int_id_col("revenue_key"), _num_col("net", data_type="double")]
+        assert "revenue_key" not in _measurable_columns(rows)
+        assert _grain_column(rows) == "revenue_key"
+        assert "net" in _measurable_columns(rows)
+
+    def test_fk_participation_beats_type_and_name(self):
+        # A continuous-typed column that is actually a join key (key_hints) is a
+        # key regardless of its type/name -- FK participation is the primary signal.
+        rows = [_num_col("amount", unique=True, data_type="double")]
+        assert _grain_column(rows, key_hints={"amount"}) == "amount"
+        assert "amount" not in _measurable_columns(rows, {"amount"})
+
+    def test_measure_and_grain_agree_on_every_column(self):
+        # The invariant: a column is never both a measure and the grain.
+        rows = [_int_id_col("k"), _num_col("m1", data_type="double"),
+                _num_col("m2", data_type="decimal(10,2)"), _attr_col("label")]
+        measures = set(_measurable_columns(rows))
+        grain = _grain_column(rows)
+        assert grain not in measures
+        assert measures == {"m1", "m2"}
+        assert grain == "k"
+
+    def test_unknown_type_uninformative_name_falls_back_to_identifier(self):
+        # Thin/federated profiling, no data_type, uninformative name: a unique
+        # numeric reads as an ID (conservative default).
+        rows = [{"column_name": "x", "has_numeric_stats": True, "null_rate": 0.0,
+                 "is_unique_candidate": True, "cardinality_ratio": 1.0}]
+        assert _measurable_columns(rows) == []
+        assert _grain_column(rows) == "x"
+
+
+class TestNameIsAMildTiebreakerNotAGate:
+    """The name prior is consulted ONLY where the data is silent (unknown-type
+    unique numeric) and NEVER overrides FK participation or a clear type."""
+
+    def test_name_hint_is_token_based(self):
+        assert _name_hint("account") is None          # NOT "count" (substring)
+        assert _name_hint("account_id") == "key"
+        assert _name_hint("net_revenue") == "measure"
+        assert _name_hint("order_counts") == "measure"  # plural stripped
+        assert _name_hint("region") is None
+        assert _name_hint("revenue_id") is None        # both signals -> no hint
+
+    def test_name_breaks_tie_only_when_type_unknown(self):
+        # Unknown data_type + measure-ish name -> measure; key-ish/blank -> ID.
+        measure_named = {"column_name": "gross_amount", "has_numeric_stats": True,
+                         "null_rate": 0.0, "is_unique_candidate": True,
+                         "cardinality_ratio": 1.0}  # no data_type
+        key_named = {"column_name": "member_id", "has_numeric_stats": True,
+                     "null_rate": 0.0, "is_unique_candidate": True,
+                     "cardinality_ratio": 1.0}      # no data_type
+        assert _is_key_like(measure_named) is False   # -> measure
+        assert _is_key_like(key_named) is True        # -> identifier
+
+    def test_name_does_not_override_a_clear_type(self):
+        # Clear CONTINUOUS type beats a key-ish name; clear INTEGER type beats a
+        # measure-ish name. Data wins whenever it speaks.
+        cont_key_named = _num_col("member_id", unique=True, data_type="decimal(9,2)")
+        int_measure_named = _int_id_col("total_amount", data_type="bigint")
+        assert _is_key_like(cont_key_named) is False  # still a measure
+        assert _is_key_like(int_measure_named) is True  # still an identifier
+
+    def test_name_does_not_override_fk_participation(self):
+        # A measure-ish name that is actually an FK stays a key.
+        col = _num_col("sales_amount", unique=True, data_type="double")
+        assert _is_key_like(col, key_hints={"sales_amount"}) is True
+
+    def test_grain_name_nudge_orders_equal_candidates(self):
+        # Two unknown-type unique integers; the id-named one is preferred as grain
+        # (ordering nudge only -- both remain key-like).
+        a = {"column_name": "seq", "has_numeric_stats": True, "null_rate": 0.0,
+             "is_unique_candidate": True, "cardinality_ratio": 1.0}
+        b = {"column_name": "customer_key", "has_numeric_stats": True,
+             "null_rate": 0.0, "is_unique_candidate": True, "cardinality_ratio": 1.0}
+        assert _grain_column([a, b]) == "customer_key"
+
+
+class TestNoAnchorRecommendsOneNotTableCount:
+    def test_all_dimension_schema_recommends_one_not_table_count(self):
+        # No fact/source/bridge and no measures anywhere: must recommend a single
+        # starter view, never the raw table count (the reintroduced-bug guard).
+        tables = ["c.s.dim_a", "c.s.dim_b", "c.s.dim_c", "c.s.dim_d"]
+        fks = [_fk("c.s.dim_a", "b_id", "c.s.dim_b", "id", conf=0.9)]
+        profiling = {t: [_key_col("id"), _attr_col("label")] for t in tables}
+        rec = recommend_erd(tables, fk_rows=fks, profiling_by_table=profiling)
+        assert rec.sufficiency.metric_views_recommended == 1
+        assert any("no clear fact/grain" in r for r in rec.sufficiency.reasons)


### PR DESCRIPTION
Three focused changes on top of `dev` (which already has this branch's earlier work). 4 files, +352/−125.

## 1. `fix(erd)`: data-driven key/measure classification + no-anchor view count
Supersedes the hardcoded column-name heuristics shipped earlier on this branch, which over-fit a single schema's vocabulary. Key-vs-measure is now decided from data:
- **FK participation** (`key_hints`) first — a column that joins is a key, whatever it's named.
- Then **column type + uniqueness** — a continuous numeric (double/decimal) is a measure even when unique; a unique integer is an identifier.
- Column **names** are demoted to a *mild tiebreaker*, used only where the data is silent (a unique numeric whose `data_type` is unknown, e.g. thin/federated profiling) plus a light ordering nudge among equal grain candidates. They never override an FK or a clear type.

Also fixes the no-clear-anchor fallback that had reintroduced the original bug: an all-dimension / measure-less schema no longer degenerates to a per-table view count — it recommends a single starter view plus the diminishing orphan bonus.

`_measurable_columns` and `_grain_column` now share `_is_key_like`, so the two never disagree about a column.

## 2. `fix(security)`: validate model endpoint before `AI_QUERY` interpolation
The `AI_QUERY()` model argument is a SQL literal that cannot be a bind parameter, so a request-supplied `model_endpoint` was interpolated into the statement text (the prompt itself is safely bound). Adds `_safe_model_endpoint()` — validates against a serving-endpoint charset (`^[A-Za-z0-9_.-]{1,128}$`), raises HTTP 400 otherwise — applied at every request-derived `AI_QUERY` sink. Constant-model sinks are untouched.

## 3. `docs(roadmap)`: reconciliation, de-dup, api_server split enabler
Reconciles the consolidated roadmap against the code, removes a duplicate, adds a do-first `api_server.py` split enabler and a federation LIMIT-0 KPI-validation item.

## Testing
- Core unit suite green (3220 tests) via `run_tests.sh -q`.
- ERD suite (63 tests) proves the classification is name-independent (key-named decimal stays a measure; measure-named integer stays an identifier; FK beats both) and that the name prior is subordinate, not a gate.

## Note
The branch is 2 commits behind `dev` (both are prior merges of this same branch). No file overlap with these changes, so no conflict expected.

This pull request and its description were written by Isaac.